### PR TITLE
Typo in topcat.json.example.

### DIFF
--- a/yo/app/config/topcat.json.example
+++ b/yo/app/config/topcat.json.example
@@ -450,7 +450,7 @@
                             ]
                         },
                         {
-                            "label": "METATABS.DATASET_TYPE.TABTITLE",
+                            "title": "METATABS.DATASET_TYPE.TABTITLE",
                             "items": [
                                 {
                                     "field": "datasetType.name"


### PR DESCRIPTION
The title of a metatab must be declared as "title" rather then as "label".