### PR TITLE
More fixes in topcat.json.example

### DIFF
--- a/yo/app/config/topcat.json.example
+++ b/yo/app/config/topcat.json.example
@@ -440,12 +440,12 @@
                                 {
                                     "label": "METATABS.DATASET.START_DATE",
                                     "field": "startDate",
-                                    "template": "{{content.value | date:'yyyy-MM-dd'}}"
+                                    "template": "{{item.value | date:'yyyy-MM-dd'}}"
                                 },
                                 {
                                     "label": "METATABS.DATASET.END_DATE",
                                     "field": "endDate",
-                                    "template": "{{content.value | date:'yyyy-MM-dd'}}"
+                                    "template": "{{item.value | date:'yyyy-MM-dd'}}"
                                 }
                             ]
                         },
@@ -497,7 +497,7 @@
                                 {
                                     "label": "METATABS.DATAFILE.SIZE",
                                     "field": "fileSize",
-                                    "template": "{{content.value | bytes}}"
+                                    "template": "{{item.value | bytes}}"
                                 },
                                 {
                                     "field": "location"


### PR DESCRIPTION
"template" requires "item.value" rather then "content.value".