### PR TITLE
Use relative path for templateUrl

### DIFF
--- a/yo/app/scripts/directives/datetime-picker.directive.js
+++ b/yo/app/scripts/directives/datetime-picker.directive.js
@@ -8,7 +8,7 @@
     app.directive('datetimePicker', function(){
         return {
             restrict: 'A',
-            templateUrl: '/views/datetime-picker.html',
+            templateUrl: 'views/datetime-picker.html',
             controller: "DatetimePickerController as datetimePickerController",
             scope: {
                 value: '=ngModel'


### PR DESCRIPTION
Use relative path for views/datetime-picker.html otherwise a TopCAT instance running behind a reverse proxy with a different root_url will fail, e.g.:

TopCAT instance behind reverse proxy using the following url ``https://www.example.com/topcat``
with this change the resulting url is ``https://www.example.com/topcat/views/datetime-picker.html``

without this change the resulting url is ``https://www.example.com/views/datetime-picker.html`` which
leads to file not found (http error 404)