### PR TITLE
Fix wrong attribute name in lang.json

### DIFF
--- a/yo/app/languages/lang.json
+++ b/yo/app/languages/lang.json
@@ -530,7 +530,7 @@
             "TABTITLE" : "Datafile Details",
             "NAME" : "Name",
             "DESCRIPTION" : "Description",
-            "SIZE" : "File Size",
+            "FILE_SIZE" : "File Size",
             "LOCATION" : "Location",
             "PARAMETERS" : "Parameters"
         }

--- a/yo/app/languages/lang.json.example
+++ b/yo/app/languages/lang.json.example
@@ -529,7 +529,7 @@
             "TABTITLE" : "Datafile Details",
             "NAME" : "Name",
             "DESCRIPTION" : "Description",
-            "SIZE" : "File Size",
+            "FILE_SIZE" : "File Size",
             "LOCATION" : "Location",
             "PARAMETERS" : "Parameters"
         }


### PR DESCRIPTION
There seem to be a wrong attribute name in lang.json.  At least, the current snapshot topcat-2.2.1-20170103.153556-2 searches for `METATABS.DATAFILE.FILE_SIZE`, but the included lang.json.example defines `METATABS.DATAFILE.SIZE`.