### PR TITLE
DATASET_COUNT and DATAFILE_COUNT is missing in lang.json.example

### DIFF
--- a/yo/app/languages/lang.json.example
+++ b/yo/app/languages/lang.json.example
@@ -103,6 +103,8 @@
                 "END_DATE": "End Date",
                 "DOI": "Doi",
                 "RELEASE_DATE": "Release Date",
+                "DATAFILE_COUNT": "File Count",
+                "DATASET_COUNT": "Dataset Count",
                 "SIZE" : "Size",
                 "FACILITY" : "Facility",
                 "RUN_NUMBER" : "Run Number"
@@ -118,6 +120,7 @@
                 "COMPLETE": "complete",
                 "CREATE_TIME": "Create Time",
                 "MOD_TIME": "Modified Time",
+                "DATAFILE_COUNT": "File Count",
                 "SIZE" : "Size",
                 "RUN_NUMBER_RANGE" : "Run Numbers",
                 "FACILITY" : "Facility"


### PR DESCRIPTION
If I deploy topcat 2.2.1 with the provided example lang.json, using as suggested `datasetCount` and `datafileCount` rather then `size` in the gid options, I get missing language definitions in the column header.  Apparently lang.json must define `BROWSE.INVESTIGATION.DATAFILE_COUNT`, `BROWSE.INVESTIGATION.DATASET_COUNT`, and `BROWSE.DATASET.DATAFILE_COUNT`.