### PR TITLE
Handle download transport type http similarly to https

### DIFF
--- a/src/main/java/org/icatproject/topcat/StatusCheck.java
+++ b/src/main/java/org/icatproject/topcat/StatusCheck.java
@@ -71,7 +71,7 @@ public class StatusCheck {
       int pollDelay = Integer.valueOf(properties.getProperty("poll.delay", "600"));
       int pollIntervalWait = Integer.valueOf(properties.getProperty("poll.interval.wait", "600"));
 
-      TypedQuery<Download> query = em.createQuery("select download from Download download where download.isDeleted != true and download.status != org.icatproject.topcat.domain.DownloadStatus.EXPIRED and (download.status = org.icatproject.topcat.domain.DownloadStatus.PREPARING or (download.status = org.icatproject.topcat.domain.DownloadStatus.RESTORING and download.transport = 'https') or (download.email != null and download.isEmailSent = false))", Download.class);
+      TypedQuery<Download> query = em.createQuery("select download from Download download where download.isDeleted != true and download.status != org.icatproject.topcat.domain.DownloadStatus.EXPIRED and (download.status = org.icatproject.topcat.domain.DownloadStatus.PREPARING or (download.status = org.icatproject.topcat.domain.DownloadStatus.RESTORING and download.transport in ('https','http')) or (download.email != null and download.isEmailSent = false))", Download.class);
       List<Download> downloads = query.getResultList();
 
       for(Download download : downloads){
@@ -107,7 +107,7 @@ public class StatusCheck {
         em.flush();
         lastChecks.remove(download.getId());
         sendDownloadReadyEmail(download);
-      } else if(download.getTransport().equals("https") && idsClient.isPrepared(download.getPreparedId())){
+      } else if(download.getTransport().matches("https|http") && idsClient.isPrepared(download.getPreparedId())){
         download.setStatus(DownloadStatus.COMPLETE);
         download.setCompletedAt(new Date());
         download.setIsEmailSent(true);
@@ -201,7 +201,7 @@ public class StatusCheck {
         download.setSize(-1);
       }
 
-      if (download.getIsTwoLevel() || !download.getTransport().equals("https")) {
+      if (download.getIsTwoLevel() || !download.getTransport().matches("https|http")) {
         download.setStatus(DownloadStatus.RESTORING);
       } else {
         download.setStatus(DownloadStatus.COMPLETE);

--- a/yo/app/scripts/controllers/download-cart.controller.js
+++ b/yo/app/scripts/controllers/download-cart.controller.js
@@ -19,7 +19,7 @@
         this.isStaged = function(){
             var out = false;
             _.each(this.downloads, function(download){
-                if(download.transportType != 'https' && download.transportType != 'smartclient'){
+                if((!download.transportType.match(/https|http/)) && download.transportType != 'smartclient'){
                     out = true;
                     return false;
                 }
@@ -97,7 +97,7 @@
                 promises.push(download.facility.user().submitCart(download.fileName, download.transportType, that.email, timeout.promise).then(function(response){
                     return download.facility.user().downloads(["where download.id = ?",response.downloadId]).then(function(downloads){
                         var download = downloads[0];
-                        if(download.transport == 'https' && download.status == 'COMPLETE'){
+                        if(download.transport.match(/https|http/) && download.status == 'COMPLETE'){
                             var url = download.transportUrl + '/ids/getData?preparedId=' + download.preparedId + '&outname=' + download.fileName;
                             var iframe = $('<iframe>').attr('src', url).css({
                                 position: 'absolute',

--- a/yo/app/scripts/controllers/downloads.controller.js
+++ b/yo/app/scripts/controllers/downloads.controller.js
@@ -27,7 +27,7 @@
             enableHiding: false,
             cellTemplate : [
                 '<div class="ui-grid-cell-contents">',
-                    '<span ng-if="row.entity.transport == \'https\'">',
+                    '<span ng-if="row.entity.transport == \'https\' ||  row.entity.transport == \'http\'">',
                         '<a ng-if="row.entity.status == \'COMPLETE\'" href="{{row.entity.transportUrl + \'/ids/getData?preparedId=\' + row.entity.preparedId + \'&outname=\' + row.entity.fileName}}" translate="DOWNLOAD.ACTIONS.LINK.HTTP_DOWNLOAD.TEXT" class="btn btn-primary btn-xs" uib-tooltip="{{\'DOWNLOAD.ACTIONS.LINK.HTTP_DOWNLOAD.TOOLTIP.TEXT\' | translate}}" tooltip-placement="left" tooltip-append-to-body="true"></a>',
                         '<span ng-if="row.entity.status != \'COMPLETE\'" class="inline-block" uib-tooltip="{{\'DOWNLOAD.ACTIONS.LINK.NON_ACTIVE_DOWNLOAD.TOOLTIP.TEXT\' | translate}}" tooltip-placement="left" tooltip-append-to-body="true"><button translate="DOWNLOAD.ACTIONS.LINK.NON_ACTIVE_DOWNLOAD.TEXT" class="btn btn-primary btn-xs disabled"></button></span>',
                     '</span> ',


### PR DESCRIPTION
Fixes #364

Extend explicit tests of download transport (type) against https to
cover http as well.