### PR TITLE
Fix Protractor and Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ before_script:
   - chmod 0755 ci/travis.rb
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start -screen 0 1280x1024x16
+  - nohup bash -c "./nodemodules/protractor/bin/webdriver-manager start 2>&1 &"
+  - sleep 5
 script:
   - ci/travis.rb
 addons:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,6 +22,7 @@ Vagrant.configure(2) do |config|
     sudo debconf-set-selections <<< "mysql-server mysql-server/root_password password secret"
     sudo debconf-set-selections <<< "mysql-server mysql-server/root_password_again password secret"
     sudo apt-get --assume-yes install mysql-server apache2 git software-properties-common python-software-properties unzip -q build-essential openjdk-8-jdk dos2unix ruby-dev
+    sudo apt-get install libgconf2-dev -y
     echo "create database icat;" | mysql -u root --password=secret
     echo "create database topcat;" | mysql -u root --password=secret
     echo "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY 'secret' WITH GRANT OPTION" | mysql -u root --password=secret

--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -123,7 +123,7 @@ exec %{
   unzip -o topcat-*.zip
   cp provision/topcat.properties ./topcat
   cp provision/topcat-setup.properties ./topcat
-  cp ../yo/app/config/topcat_dev.json.example ./topcat/topcat.json
+  cp ../yo/app/config/topcat_ci.json.example ./topcat/topcat.json
   cp ../yo/app/languages/lang.json ./topcat
   cp ../yo/app/styles/topcat.css ./topcat
   cd topcat

--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -51,6 +51,7 @@ exec %{
   asadmin delete-network-listener http-listener-2
   asadmin create-network-listener --listenerport 8181 --protocol http-listener-2 http-listener-2
   asadmin create-ssl --type http-listener --certname s1as --ssl3enabled=false --ssl3tlsciphers +TLS_RSA_WITH_AES_256_CBC_SHA,+TLS_RSA_WITH_AES_128_CBC_SHA http-listener-2
+  asadmin set configs.config.server-config.network-config.protocols.protocol.http-listener-2.http.request-timeout-seconds=-1
 
   wget http://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.37.zip
   unzip  mysql-connector-java-5.1.37.zip

--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -24,6 +24,7 @@ exec %{
   cd install
 
   sudo apt-get --assume-yes install apache2 git software-properties-common python-software-properties unzip build-essential dos2unix
+  sudo apt-get install libgconf2-dev -y
 
   echo "USE mysql; UPDATE user SET password=PASSWORD('secret') WHERE user='root'; FLUSH PRIVILEGES; " | mysql -u root
   echo "create database icat;" | mysql -u root --password=secret

--- a/yo/app/config/topcat_ci.json.example
+++ b/yo/app/config/topcat_ci.json.example
@@ -1,0 +1,571 @@
+{    
+    "site": {
+        "topcatUrl": "http://localhost:8080",
+        "home" : "my-data",
+        "enableEuCookieLaw" : true,
+        "enableKiloBinaryBytes": false,
+        "paging" : {
+            "pagingType": "scroll",
+            "paginationNumberOfRows": 10,
+            "paginationPageSizes": [
+                10,
+                25,
+                50,
+                100,
+                1000
+            ],
+            "scrollPageSize": 50,
+            "scrollRowFromEnd": 10
+        },
+        "breadcrumb": {
+            "maxTitleLength": 30
+        },
+        "search": {
+            "enableParameters": true,
+            "enableSamples": false,
+            "gridOptions": {
+                "investigation": {
+                    "columnDefs": [
+                        {
+                            "field": "title",
+                            "link": true
+                        },
+                        {
+                            "field": "visitId",
+                            "link": true
+                        },
+                        {
+                            "field": "size|bytes"
+                        },
+                        {
+                            "field": "investigationInstrument.fullName"
+                        },
+                        {
+                            "field": "startDate"
+                        },
+                        {
+                            "field": "endDate"
+                        }
+                    ]
+                },
+                "dataset": {
+                    "enableSelection": true,
+                    "columnDefs": [
+                        {
+                            "field": "name",
+                            "link": true
+                        },
+                        {
+                            "field": "size|bytes"
+                        },
+                        {
+                            "field": "investigation.title",
+                            "link": "investigation"
+                        },
+                        {
+                            "field": "createTime"
+                        },
+                        {
+                            "field": "modTime"
+                        }
+                    ]
+                },
+                "datafile": {
+                    "enableSelection": true,
+                    "columnDefs": [
+                        {
+                            "field": "name"
+                        },
+                        {
+                            "field": "location"
+                        },
+                        {
+                            "field": "fileSize|bytes"
+                        },
+                        {
+                            "field": "dataset.name",
+                            "link": "dataset"
+                        },
+                        {
+                            "field": "datafileModTime"
+                        }
+                    ]
+                }
+            }
+        },
+        "browse":{
+            "gridOptions": {
+                "columnDefs": [
+                    {
+                        "field": "fullName",
+                        "link": true
+                    },
+                    {
+                        "field": "name"
+                    }
+                ]
+            },
+            "metaTabs": [
+                {
+                    "title": "METATABS.FACILITY.TABTITLE",
+                    "items": [
+                        {
+                            "field": "fullName"
+                        },
+                        {
+                            "field": "description"
+                        },
+                        {
+                            "field": "name"
+                        },
+                        {
+                            "field": "url"
+                        }
+                    ]
+                }
+            ]
+        },
+        "cart":{
+            "maxDatafileCount": 100000,
+            "maxTotalSize": 100000000,
+            "gridOptions": {
+                "columnDefs": [
+                    {
+                        "field": "name"
+                    },
+                    {
+                        "field": "entityType"
+                    },
+                    {
+                        "field": "size"
+                    },
+                    {
+                        "field": "datafileCount"
+                    },
+                    {
+                        "field": "facilityName"
+                    }
+                ]
+            }
+        },
+        "myDownloads":{
+            "gridOptions": {
+                "columnDefs": [
+                    {
+                        "field": "fileName"
+                    },
+                    {
+                        "field": "transport"
+                    },
+                    {
+                        "field": "status"
+                    },
+                    {
+                        "field": "createdAt"
+                    }
+                ]
+            }
+        },
+        "pages" : [
+            {
+                "name" : "about",
+                "addToNavBar": {
+                    "label" : "About",
+                    "align" : "left"
+                }
+
+            },
+            {
+                "name" : "contact",
+                "addToNavBar": {
+                    "label" : "Contact",
+                    "align" : "left"
+                }
+
+            },
+            {
+                "name" : "help",
+                "addToNavBar": {
+                    "label" : "Help",
+                    "align" : "left"
+                }
+            },
+            {
+                "name" : "globus-help"
+            },
+            {
+                "name" : "cookie-policy"
+            }
+
+        ]
+    },
+    "facilities": [
+        {
+            "name": "LILS",
+            "title": "Lorum Ipsum Light Source",
+            "idsUrl": "http://localhost:8080",
+            "icatUrl": "http://localhost:8080",
+            "idsUploadDatafileFormat": "upload",
+            "idsUploadDatasetType": "DatasetType 1",
+            "idsUploadMaxTotalFileSize": 10000000000,
+            "hierarchy": [
+                "facility",
+                "proposal",
+                "investigation",
+                "dataset",
+                "datafile"
+            ],
+            "authenticationTypes": [
+                {
+                    "title": "Simple",
+                    "plugin": "simple"
+                },
+                {
+                    "title": "DB",
+                    "plugin": "db"
+                }
+            ],
+            "downloadTransportTypes": [
+                {
+                    "type" : "http",
+                    "idsUrl": "http://localhost:8080"
+                },
+                {
+                    "type" : "globus",
+                    "idsUrl": "http://localhost:8080"
+                }
+            ],
+            "admin":{
+                "gridOptions": {
+                    "columnDefs": [
+                        {
+                            "field": "userName"
+                        },
+                        {
+                            "field": "preparedId"
+                        },
+                        {
+                            "field": "transport"
+                        },
+                        {
+                            "field": "status"
+                        },
+                        {
+                            "field": "size"
+                        },
+                        {
+                            "field": "createdAt"
+                        },
+                        {
+                            "field": "isDeleted"
+                        }
+                    ]
+                }
+            },
+            "myData": {
+                "entityType" : "investigation",
+                "gridOptions": {
+                    "enableSelection": false,
+                    "columnDefs": [
+                        {
+                            "field": "title",
+                            "title": "BROWSE.COLUMN.INVESTIGATION.TITLE",
+                            "link": true
+                        },
+                        {
+                            "field": "visitId",
+                            "title": "BROWSE.COLUMN.INVESTIGATION.VISIT_ID",
+                            "link": true
+                        },
+                        {
+                            "field": "datafileParameter.numericValue",
+                            "title": "BROWSE.COLUMN.INVESTIGATION.RUN_NUMBER",
+                            "where": "datafileParameterType.name = 'run_number'"
+                        },
+                        {
+                            "field": "investigationInstrument.fullName",
+                            "title": "BROWSE.COLUMN.INSTRUMENT.NAME"
+                        },
+                        {
+                            "field": "size",
+                            "title": "BROWSE.COLUMN.INVESTIGATION.SIZE"
+                        },
+                        {
+                            "field": "startDate",
+                            "title": "BROWSE.COLUMN.INVESTIGATION.START_DATE",
+                            "excludeFuture": true,
+                            "sort": {
+                              "direction": "desc",
+                              "priority": 1
+                            }
+                        },
+                        {
+                            "field": "endDate",
+                            "title": "BROWSE.COLUMN.INVESTIGATION.END_DATE"
+                        }
+                    ]
+                }
+            },
+            "browse":{
+                "instrument": {
+                    "gridOptions": {
+                        "columnDefs": [
+                            {
+                                "field": "fullName",
+                                "link": true
+                            }
+                        ]
+                    },
+                    "metaTabs": [
+                        {
+                            "title": "METATABS.INSTRUMENT.TABTITLE",
+                            "items": [
+                                {
+                                    "field": "fullName"
+                                },
+                                {
+                                    "field": "description"
+                                },
+                                {
+                                    "field": "type"
+                                },
+                                {
+                                    "field": "url"
+                                }
+                            ]
+                        },
+                        {
+                            "title": "METATABS.INSTRUMENT_SCIENTISTS.TABTITLE",
+                            "items": [
+                                {
+                                    "field": "instrumentScientist.fullName"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "facilityCycle": {
+                    "gridOptions": {
+                        "columnDefs": [
+                            {
+                                "field": "name",
+                                "link": true
+                            },
+                            {
+                                "field": "description"
+                            },
+                            {
+                                "field": "startDate"
+                            },
+                            {
+                                "field": "endDate"
+                            }
+                        ]
+                    }
+                },
+                "proposal": {
+                    "gridOptions": {
+                        "columnDefs": [
+                            {
+                                "field": "name",
+                                "link": true
+                            }
+                        ]
+                    }
+                },
+                "investigation": {
+                    "gridOptions": {
+                        "enableSelection": true,
+                        "columnDefs": [
+                            {
+                                "field": "title",
+                                "sort": {
+                                    "direction": "asc"
+                                },
+                                "link": true
+                            },
+                            {
+                                "field": "visitId",
+                                "link": true
+                            },
+                            {
+                                "field": "investigationVisit",
+                                "jpqlFilter": "CONCAT(investigation.name, '-', investigation.visitId)",
+                                "jpqlSort": "investigation.name, investigation.visitId",
+                                "cellTemplate": "<div class='ui-grid-cell-contents'>{{row.entity.name}}-{{row.entity.visitId}}</div>",
+                                "breadcrumb": true,
+                                "breadcrumbTemplate": "{{item.entity.name}}-{{item.entity.visitId}}"
+                            },
+                            {
+                                "field": "name",
+                                "link": true
+                            },
+                            {
+                                "field": "size"
+                            },
+                            {
+                                "field": "name"
+                            },
+                            {
+                                "field": "startDate",
+                                "excludeFuture": true
+                            },
+                            {
+                                "field": "endDate"
+                            }
+                        ]
+                    },
+                    "metaTabs": [
+                        {
+                            "title": "METATABS.INVESTIGATION.TABTITLE",
+                            "items": [
+                                {
+                                    "field": "name"
+                                },
+                                {
+                                    "field": "title"
+                                },
+                                {
+                                    "field": "summary"
+                                },
+                                {
+                                    "field": "startDate"
+                                },
+                                {
+                                    "field": "endDate"
+                                }
+                            ]
+                        },
+                        {
+                            "title": "METATABS.INVESTIGATION_USERS.TABTITLE",
+                            "items": [
+                                {
+                                    "label": "",
+                                    "field": "investigationUserPivot.role",
+                                    "template": "<span class='label'>{{item.value}}</span><span>{{item.entity.find('investigationUser.fullName')[0]}}</span>"
+                                }
+                            ]
+                        },
+                        {
+                            "title": "METATABS.INVESTIGATION_SAMPLES.TABTITLE",
+                            "items": [
+                                {
+                                    "field": "name"
+                                }
+                            ]
+                        },
+                        {
+                            "title": "METATABS.PUBLICATIONS.TABTITLE",
+                            "items": [
+                                {
+                                    "field": "fullReference"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "dataset": {
+                    "gridOptions": {
+                        "enableSelection": true,
+                        "enableUpload": true,
+                        "columnDefs": [
+                            {
+                                "field": "name",
+                                "link": true
+                            },
+                            {
+                                "field": "size"
+                            },
+                            {
+                                "field": "createTime"
+                            },
+                            {
+                                "field": "modTime"
+                            }
+                        ]
+                    },
+                    "metaTabs": [
+                        {
+                            "title": "METATABS.DATASET.TABTITLE",
+                            "items": [
+                                {
+                                    "field": "name"
+                                },
+                                {
+                                    "field": "description"
+                                },
+                                {
+                                    "field": "startDate"
+                                },
+                                {
+                                    "field": "endDate"
+                                }
+                            ]
+                        },
+                        {
+                            "title": "METATABS.DATASET_TYPE.TABTITLE",
+                            "items": [
+                                {
+                                    "field": "name"
+                                },
+                                {
+                                    "field": "description"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "datafile": {
+                    "gridOptions": {
+                        "enableSelection": true,
+                        "enableDownload": true,
+                        "columnDefs": [
+                            {
+                                "field": "name"
+                            },
+                            {
+                                "field": "location"
+                            },
+                            {
+                                "field": "fileSize"
+                            },
+                            {
+                                "field": "modTime"
+                            }
+                        ]
+                    },
+                    "metaTabs": [
+                        {
+                            "title": "METATABS.DATAFILE.TABTITLE",
+                            "items": [
+                                {
+                                    "field": "name"
+                                },
+                                {
+                                    "field": "description"
+                                },
+                                {
+                                    "field": "fileSize"
+                                },
+                                {
+                                    "field": "location"
+                                }
+                            ]
+                        },
+                        {
+                            "title": "METATABS.DATAFILE.TABTITLE",
+                            "items": [
+                                {
+                                    "field": "stringValue"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "plugins":[
+        
+    ]
+}

--- a/yo/test/karma.conf.js
+++ b/yo/test/karma.conf.js
@@ -89,6 +89,20 @@ module.exports = function(config) {
     // web server port
     //port: 9876,
 
+    // Custom configuration to run Chrome headless;
+    // see  <http://cvuorinen.net/2017/05/running-angular-tests-in-headless-chrome/>
+    customLaunchers: {
+      ChromeHeadless: {
+        base: 'Chrome',
+        flags: [
+          '--headless',
+          '--disable-gpu',
+          // Without a remote debugging port, Google Chrome exits immediately.
+          '--remote-debugging-port=9222',
+        ],
+      }
+    },
+
     // Start these browsers, currently available:
     // - Chrome
     // - ChromeCanary
@@ -98,7 +112,7 @@ module.exports = function(config) {
     // - PhantomJS
     // - IE (only Windows)
     browsers: [
-      'Chrome'
+      'ChromeHeadless'
     ],
 
     // Which plugins to enable

--- a/yo/test/protractor.conf.js
+++ b/yo/test/protractor.conf.js
@@ -15,7 +15,7 @@ exports.config = {
 
   capabilities: {
     'browserName': 'chrome',
-    'chromeOptions': {'args': ['--disable-extensions',  '--start-maximized']}
+    'chromeOptions': {'args': ['--headless', '--disable-extensions',  '--start-maximized']}
   },
 
   directConnect: true,

--- a/yo/test/protractor.conf.js
+++ b/yo/test/protractor.conf.js
@@ -15,7 +15,7 @@ exports.config = {
 
   capabilities: {
     'browserName': 'chrome',
-    'chromeOptions': {'args': ['--headless', '--disable-extensions',  '--start-maximized']}
+    'chromeOptions': {'args': ['--headless', '--disable-gpu', '--disable-extensions',  '--start-maximized']}
   },
 
   directConnect: true,

--- a/yo/test/spec/e2e/user.js
+++ b/yo/test/spec/e2e/user.js
@@ -5,12 +5,8 @@ describe('user', function() {
 
     browser.get('http://localhost:8080/#/login');
 
-    browser.sleep(10000);
-
     var until = protractor.ExpectedConditions;
     browser.wait(until.presenceOf(element(by.css('.is-init'))));
-
-    browser.sleep(3000);
 
     element(by.model('loginController.userName')).sendKeys('root');
     element(by.model('loginController.password')).sendKeys('root');


### PR DESCRIPTION
The key change here is to configure Travis to install a version of topcat.json that does not refer to specific external Facilities (e.g. ISIS/DLS dev). This also fixes several other problems with Protractor: added a missing library, removed superfluous and unpredictable sleeps. Changed Karma and Protractor configurations to run Chrome headlessly.