### PR TITLE
Add missing items in lang.json.example

### DIFF
--- a/yo/app/languages/lang.json.example
+++ b/yo/app/languages/lang.json.example
@@ -252,6 +252,7 @@
             "ENTITY_TYPE" : "Type",
             "FACILITY" : "Facility",
             "SIZE" : "Size",
+            "DATAFILE_COUNT" : "Datafile Count",
             "FACILITY_NAME" : "Facility",
             "ACTIONS" : "Action"
         },
@@ -613,5 +614,13 @@
                 "TEXT": "Cancel"
             }
         }
+    },
+    "FILE_SIZE_UNITS": {
+        "B": "B",
+        "KB": "kB",
+        "MB": "MB",
+        "GB": "GB",
+        "TB": "TB",
+        "PB": "PB"
     }
 }


### PR DESCRIPTION
There are a few items referenced from the current TopCAT 2.4.0 snapshot that are missing a definition in the distributed `lang.json.example` file.

One note on `FILE_SIZE_UNITS`: since the distributed `topcat.json.example` has `enableKiloBinaryBytes` set to `false`, I have chosen the corresponding decimal units `kB`, `MB`, `GB`, … If one sets `enableKiloBinaryBytes = true` one should also switch to the binary units `KiB`, `MiB`, `GiB`, …