### PR TITLE
Change upload url to simplify proxy configuration

### DIFF
--- a/src/main/java/org/icatproject/topcat/IdsUploadProxy.java
+++ b/src/main/java/org/icatproject/topcat/IdsUploadProxy.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 
 
 @ApplicationScoped
-@ServerEndpoint("/topcat/user/upload")
+@ServerEndpoint("/topcat/ws/user/upload")
 public class IdsUploadProxy {
 
     private static final Logger logger = LoggerFactory.getLogger(IdsUploadProxy.class);

--- a/yo/app/scripts/services/tc-ids.service.js
+++ b/yo/app/scripts/services/tc-ids.service.js
@@ -135,7 +135,7 @@
               topcatUrl = "ws://" + topcatUrl.replace(/^http:\/\//, '');
             }
 
-            var currentUrl = topcatUrl + "/topcat/user/upload?" + _.map(queryParams, function(v, k){ return encodeURIComponent(k) + "=" + encodeURIComponent(v) }).join('&');
+            var currentUrl = topcatUrl + "/topcat/ws/user/upload?" + _.map(queryParams, function(v, k){ return encodeURIComponent(k) + "=" + encodeURIComponent(v) }).join('&');
 
             var connection = new WebSocket(currentUrl);
 


### PR DESCRIPTION
Inserted "ws/" into the upload url to make it easier to distinguish WebSockets urls in proxy configuration.
Fixes #372 (when used in conjunction with proxy configuration).