### PR TITLE
Restore copy of topcat.css into styles in setup

### DIFF
--- a/src/main/scripts/setup
+++ b/src/main/scripts/setup
@@ -35,6 +35,7 @@ if arg == "INSTALL":
         files = []
         files.append(["topcat.json", "config"])
         files.append(["lang.json", "languages"])
+        files.append(["topcat.css", "styles"])
 
         if os.path.exists("logback.xml"): files.append(["logback.xml", "WEB-INF/classes"])
 


### PR DESCRIPTION
Fixes #379 - see discussion there for reasoning for this. In effect
reverting a change made in Jan 2017.