### PR TITLE
Issue#383 make search removable

### DIFF
--- a/src/site/markdown/installation.md.vm
+++ b/src/site/markdown/installation.md.vm
@@ -352,6 +352,7 @@ An example (partial) configuration:
 {
   "site": {
     "search": {
+        "disabled": false,
         "enableTextBox": true,
         "enableDateRange": true,
         "enableParameters": true,
@@ -368,6 +369,7 @@ An example (partial) configuration:
   }
 }
 ```
+  * "disabled" - if true then the Search tab will not be added. Can be omitted, defaulting to false.
   * "enableTextBox" - specifies whether the main search text box feature should be enabled or not. Can be true or false.
   * "enableDateRange" - specifies whether the date range feature should be enabled or not. Can be true or false.
   * "enableParameters" - specifies whether the parameter search feature should be enabled or not. Can be true or false.

--- a/src/site/markdown/release-notes.md
+++ b/src/site/markdown/release-notes.md
@@ -7,6 +7,7 @@
 * fix issue #381 : IcatClient.getFullName returns UserName if no FullName is found
 * fix issue #384 : Cart no longer inherited by different user on same browser; also, if
   a different user logs in, the browse path is reset.
+* added optional "disabled" flag to site.search configuration in topcat.json. If present and true, the Search tab will not be added.
 
 
 ## 2.4.0

--- a/yo/app/scripts/controllers/home.controller.js
+++ b/yo/app/scripts/controllers/home.controller.js
@@ -19,14 +19,17 @@
     			translate: "MAIN_NAVIGATION.MAIN_TAB.BROWSE",
     			sref: "home.browse.facility",
     			showState: "home.browse"
-    		},
-    		{
-    			name: "search",
-    			translate: "MAIN_NAVIGATION.MAIN_TAB.SEARCH",
-    			sref: "home.search.start",
-    			showState: "home.search"
     		}
     	];
+
+        if( ! tc.config().search.disabled ){
+            existingTabs.push({
+                name: "search",
+                translate: "MAIN_NAVIGATION.MAIN_TAB.SEARCH",
+                sref: "home.search.start",
+                showState: "home.search"                
+            })
+        };
 
     	var otherTabs = _.map(tc.ui().mainTabs(), function(otherTab){
     		return {

--- a/yo/app/scripts/services/object-validator.service.js
+++ b/yo/app/scripts/services/object-validator.service.js
@@ -91,6 +91,7 @@
                         message: { _type: 'string' }
                     },
                     search: {
+                        disabled: { _type: 'boolean', _mandatory: false },
                         enableTextBox: { _type: 'boolean', _mandatory: false },
                         enableDateRange: { _type: 'boolean', _mandatory: false },
                         enableParameters: { _type: 'boolean', _mandatory: false },


### PR DESCRIPTION
Added optional site.search.disabled flag to topcat.json. When false, the Search tab is not added.
Fixes #383.
