### PR TITLE
Make setup mail properties optional

### DIFF
--- a/src/main/scripts/setup
+++ b/src/main/scripts/setup
@@ -30,7 +30,15 @@ if arg == "INSTALL":
 
         actions.registerDB("topcat", props["db.driver"], props["db.url"], props["db.username"], props["db.password"])
 
-        actions.createMailResource("mail/topcat", props["mail.host"], props["mail.user"], props["mail.from"], props["mail.property"])
+        # Only create the mail resource if all mail properties are defined.
+        # NOTE: if the mail resource is not created, then mail.enable MUST be false in topcat.properties
+        
+        missing = [k for k in ("mail.host","mail.user","mail.from","mail.property") if k not in props];
+        if not missing:
+            print("Creating mail resource...");
+            actions.createMailResource("mail/topcat", props["mail.host"], props["mail.user"], props["mail.from"], props["mail.property"])
+        else:
+            print "Not creating mail resource as following is/are not set:", missing;
  
         files = []
         files.append(["topcat.json", "config"])

--- a/src/site/markdown/installation.md.vm
+++ b/src/site/markdown/installation.md.vm
@@ -114,6 +114,9 @@ Note: '#'s are comments.
   mail.property=mail.smtp.port="25":mail.smtp.from="no-reply@example.com"
 ```
 
+The mail.xxx properties can be omitted if email support is not required in Topcat.
+In this case, mail.enable in topcat.properties MUST NOT be set to true. This is NOT checked during setup.
+
 $h2 topcat.properties
 
 $h3 Upgrade from 2.3.6 to 2.4.0


### PR DESCRIPTION
If any of the mail.xxx properties in topcat-setup.properties are omitted, do not create the mail resource. (Previously, omission caused setup to fail.)
In this case, mail.enable MUST NOT be set to true in topcat.properties. This is not tested during setup. Added a note to the installation notes to point this out.
Fixes #389.