### PR TITLE
Issue#398 getSize chunking

### DIFF
--- a/src/main/java/org/icatproject/topcat/IdsClient.java
+++ b/src/main/java/org/icatproject/topcat/IdsClient.java
@@ -257,6 +257,7 @@ public class IdsClient {
             String offset = generateDataSelectionOffset(offsetPrefix, currentInvestigationIds, newInvestigationId, currentDatasetIds, newDatasetId, currentDatafileIds, newDatafileId);
 
             if(offset.length() > 1024){
+            	out.add(offset);
                 currentInvestigationIds = new ArrayList<Long>();
                 currentDatasetIds = new ArrayList<Long>();
                 currentDatafileIds = new ArrayList<Long>();

--- a/src/test/java/org/icatproject/topcat/IdsClientTest.java
+++ b/src/test/java/org/icatproject/topcat/IdsClientTest.java
@@ -16,9 +16,32 @@ public class IdsClientTest {
 		chunkOffsets.setAccessible(true);
 
 		for(int i = 0; i < 10; i++){
-			for(String chunk : (List<String>) chunkOffsets.invoke(idsClient, "preparedData?sessionIds=312313-21312-312&", generateIds(i * 100, 1000), generateIds(i * 100, 1000), generateIds(i * 100, 1000))){
+			// Use the same IDs for each list of investigation/dataset/datafileIds
+			List<Long> investigationIds = generateIds(i * 100, 1000);
+			List<Long> datasetIds = generateIds(i * 100, 1000);
+			List<Long> datafileIds = generateIds(i * 100, 1000);
+			List<String> chunks = (List<String>) chunkOffsets.invoke(idsClient, "preparedData?sessionIds=312313-21312-312&", investigationIds, datasetIds, datafileIds);
+			for(String chunk : chunks){
 				assertTrue(chunk.length() <= 2048);
 			}
+			// Each ID ought to appear *somewhere* as an investigation/dataset/datafileId
+			// Careful: build process may have emptied the original entityIds lists
+			List<Long> entityIds = generateIds(i * 100, 1000);
+			boolean allFound = true;
+			for( Long id : entityIds ) {
+				boolean foundInvestigation = false;
+				boolean foundDataset = false;
+				boolean foundDatafile = false;
+				for( String chunk : chunks ) {
+					// Only look if we haven't found it in a previous chunk
+					// TODO: worry about duplicates?
+					if( ! foundInvestigation ) foundInvestigation = chunkContains(chunk, "investigation",id);
+					if( ! foundDataset )       foundDataset       = chunkContains(chunk, "dataset",id);
+					if( ! foundDatafile )      foundDatafile      = chunkContains(chunk, "datafile",id);
+				}
+				allFound = allFound && foundInvestigation && foundDataset && foundDatafile;
+			}
+			assertTrue("Not all IDs found in chunks", allFound);
 		}
 
 		String expected = "test?investigationIds=1,2,3&datasetIds=4,5,6&datafileIds=7,8,9";
@@ -37,6 +60,11 @@ public class IdsClientTest {
 		}
 
 		return out;
+	}
+	
+	private boolean chunkContains(String chunk, String entityType, Long id) {
+		// return true if chunk contains a substring of the form "<entity>Ids=m1,m2,...,mN" with some mi == id
+		return chunk.matches(".*" + entityType + "Ids=[\\d+,]*" + id.toString() + "[,\\d+]*.*");
 	}
 
 }

--- a/src/test/java/org/icatproject/topcat/IdsClientTest.java
+++ b/src/test/java/org/icatproject/topcat/IdsClientTest.java
@@ -28,20 +28,34 @@ public class IdsClientTest {
 			// Careful: build process may have emptied the original entityIds lists
 			List<Long> entityIds = generateIds(i * 100, 1000);
 			boolean allFound = true;
+			boolean foundRepeats = false;
 			for( Long id : entityIds ) {
 				boolean foundInvestigation = false;
 				boolean foundDataset = false;
 				boolean foundDatafile = false;
 				for( String chunk : chunks ) {
 					// Only look if we haven't found it in a previous chunk
-					// TODO: worry about duplicates?
-					if( ! foundInvestigation ) foundInvestigation = chunkContains(chunk, "investigation",id);
-					if( ! foundDataset )       foundDataset       = chunkContains(chunk, "dataset",id);
-					if( ! foundDatafile )      foundDatafile      = chunkContains(chunk, "datafile",id);
+					// Also look for duplicates
+					if( ! foundInvestigation ) {
+						foundInvestigation = chunkContains(chunk, "investigation",id);
+					} else {
+						foundRepeats = chunkContains(chunk, "investigation",id);
+					}
+					if( ! foundDataset ) {
+						foundDataset       = chunkContains(chunk, "dataset",id);
+					} else {
+						foundRepeats = chunkContains(chunk, "investigation",id);
+					}
+					if( ! foundDatafile ) {
+						foundDatafile      = chunkContains(chunk, "datafile",id);
+					} else {
+						foundRepeats = chunkContains(chunk, "investigation",id);
+					}
 				}
 				allFound = allFound && foundInvestigation && foundDataset && foundDatafile;
 			}
 			assertTrue("Not all IDs found in chunks", allFound);
+			assertTrue("At least one ID was repeated", ! foundRepeats);
 		}
 
 		String expected = "test?investigationIds=1,2,3&datasetIds=4,5,6&datafileIds=7,8,9";


### PR DESCRIPTION
IdsClient.getSize calls with large numbers of entityIds will be split into multiple GET requests to the IDS and summed. This should remove observed problems with overlong URLs, and so fix issue#398.