### PR TITLE
Issue#394 get size cache consistency

### DIFF
--- a/migrations/mysql_2.4.2.sql
+++ b/migrations/mysql_2.4.2.sql
@@ -1,0 +1,1 @@
+DROP TABLE 'CACHE';

--- a/migrations/oracle_2.4.2.sql
+++ b/migrations/oracle_2.4.2.sql
@@ -1,0 +1,1 @@
+DROP TABLE 'CACHE';

--- a/src/main/config/topcat.properties.example
+++ b/src/main/config/topcat.properties.example
@@ -65,3 +65,13 @@ adminUserNames=simple/root, uows/elz087, asd345, ldap/fgh123
 # The maximum number objects that can be cached before pruning will take place
 maxCacheSize=100000
 
+# The following properties allow finer control over caching of Investigation sizes.
+# Investigations can change size over time, so setting a lifetime on cached values may be useful.
+# It may be useful not to cache zero-sized Investigations at all.
+# IMPORTANT: size requests are also cached in the browser, so check settings in topcat.json too.
+
+# Lifetime in seconds for cached Investigation sizes (default is 0, which means "immortal")
+# investigationSizeCacheLifetimeSeconds=600
+
+# Whether to cache zero-sized Investigations (default is false)
+# neverCacheZeroSizedInvestigations=false

--- a/src/main/java/org/icatproject/topcat/FacilityMap.java
+++ b/src/main/java/org/icatproject/topcat/FacilityMap.java
@@ -31,6 +31,8 @@ public class FacilityMap {
 		
 		properties = Properties.getInstance();
 		
+		logger.info("FacilityMap: facility.list = '" + properties.getProperty("facility.list","") + "'");
+		
 		String[] facilities = properties.getProperty("facility.list","").split("([ ]*,[ ]*|[ ]+)");
 		
 		// Complain/log if property is not set
@@ -40,6 +42,7 @@ public class FacilityMap {
 		}
 		
 		for( String facility : facilities ){
+			logger.info("FacilityMap: looking for properties for facility '" + facility + "'...");
 			String icatUrl = properties.getProperty("facility." + facility + ".icatUrl","");
 			// Complain/log if property is not set
 			if( icatUrl.length() == 0 ){
@@ -47,6 +50,7 @@ public class FacilityMap {
 				logger.error( error );
 				throw new InternalException( error );
 			}
+			logger.info("FacilityMap: icatUrl for facility '" + facility + "' is '" + icatUrl + "'");
 			facilityIcatUrl.put( facility,  icatUrl );
 			String idsUrl = properties.getProperty("facility." + facility + ".idsUrl","");
 			// Complain/log if property is not set
@@ -55,6 +59,7 @@ public class FacilityMap {
 				logger.error( error );
 				throw new InternalException( error );
 			}
+			logger.info("FacilityMap: idsUrl for facility '" + facility + "' is '" + idsUrl + "'");
 			facilityIdsUrl.put( facility,  idsUrl );
 		}
 	}

--- a/src/main/java/org/icatproject/topcat/IdsClient.java
+++ b/src/main/java/org/icatproject/topcat/IdsClient.java
@@ -25,11 +25,17 @@ public class IdsClient {
     private HttpClient httpClient;
 
     private int timeout;
+    
+    private long investigationSizeCacheLifetime;
+    
+    private boolean neverCacheZeroSizedInvestigations;
    
     public IdsClient(String url){
         this.httpClient = new HttpClient(url + "/ids");
         Properties properties = Properties.getInstance();
         this.timeout = Integer.valueOf(properties.getProperty("ids.timeout", "-1"));
+        this.investigationSizeCacheLifetime = Long.valueOf(properties.getProperty("investigationSizeCacheLifetimeSeconds", "0"));
+        this.neverCacheZeroSizedInvestigations = Boolean.valueOf(properties.getProperty("neverCacheZeroSizedInvestigations", "false"));
     }
 
     public String prepareData(String sessionId, List<Long> investigationIds, List<Long> datasetIds, List<Long> datafileIds) throws TopcatException {
@@ -200,7 +206,16 @@ public class IdsClient {
     public Long getSize(CacheRepository cacheRepository, String sessionId, String entityType, Long entityId) throws TopcatException {
 
         String key = "getSize:" + entityType + ":" + entityId;
-        Long size = (Long) cacheRepository.get(key);
+        
+        // Set lifetime for investigation size caching from configuration (issue#394)
+        
+        Long lifetime;
+        if( "investigation".equals(entityType) ) {
+        	lifetime = this.investigationSizeCacheLifetime;
+        } else {
+        	lifetime = 0L;
+        }
+        Long size = (Long) cacheRepository.get(key,lifetime);
 
         if(size != null){
             return size;
@@ -221,7 +236,11 @@ public class IdsClient {
         }
 
         size = this.getSize(sessionId,investigationIds,datasetIds,datafileIds);
-        cacheRepository.put(key,size);
+        
+        // Never cache zero-sized investigations if so configured (issue#394)
+        if( ! (this.neverCacheZeroSizedInvestigations && size == 0 && "investigation".equals(entityType))) {
+        	cacheRepository.put(key,size);
+        }
 
         return size;
     }

--- a/src/main/java/org/icatproject/topcat/domain/Cache.java
+++ b/src/main/java/org/icatproject/topcat/domain/Cache.java
@@ -23,6 +23,10 @@ public class Cache implements Serializable {
     @Temporal(TemporalType.TIMESTAMP)
     private Date lastAccessTime;
 
+    @Column(name = "CREATION_TIME")
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date creationTime;
+
     public String getKey() {
         return key;
     }
@@ -60,8 +64,17 @@ public class Cache implements Serializable {
         this.lastAccessTime = lastAccessTime;
     }
 
+    public Date getCreationTime() {
+        return creationTime;
+    }
+
+    public void setCreationTime(Date creationTime) {
+        this.creationTime = creationTime;
+    }
+
     @PrePersist
     private void init() {
         this.lastAccessTime = new Date();
+        this.creationTime = new Date();
     }
 }

--- a/src/site/markdown/installation.md.vm
+++ b/src/site/markdown/installation.md.vm
@@ -25,6 +25,11 @@ $h2 Schema upgrade
 
 If you are using an older version of Topcat you may need to apply some migrations to your database. These can be found in the "migrations/" directory within the Topcat release.
 
+$h3 Upgrade 2.4.1 schema to 2.4.2
+
+The CACHE table now requires an extra column, CREATION_TIME. The simplest upgrade is to drop the
+existing table; this is done by the provided migration scripts.
+
 $h3 Upgrade 2.3.x schema to 2.4.0
 
 For MySQL:
@@ -119,6 +124,26 @@ In this case, mail.enable in topcat.properties MUST NOT be set to true. This is 
 
 $h2 topcat.properties
 
+$h3 New properties in 2.4.2
+
+New properties have been added to allow finer control over caching of Investigation sizes.
+Investigations can change size over time, so setting a lifetime on cached values may be useful.
+It may be useful not to cache zero-sized Investigations at all.
+Note that size requests are also cached in the browser, so check settings in topcat.json too.
+However, the browser cache is less persistent, and can be cleared by reloading the page, so
+browser cache consistency is less of an issue.
+
+These properties are optional, and the defaults preserve the original behaviour, so they need 
+not be added when upgrading.
+
+```
+  # Lifetime in seconds for cached Investigation sizes (default is 0, which means "immortal")
+  investigationSizeCacheLifetimeSeconds=600
+
+  # Whether to cache zero-sized Investigations (default is false)
+  neverCacheZeroSizedInvestigations=true
+```
+
 $h3 Upgrade from 2.3.6 to 2.4.0
 
 If you are upgrading from 2.3.6 or earlier to 2.4.0, the following properties should be added to your topcat.properties:
@@ -194,6 +219,20 @@ Note: '#'s are comments.
 
   # A list of usernames that can use the admin REST API and Topcat admin user interface
   adminUserNames=simple/root, uows/elz087, asd345, ldap/fgh123
+
+  # The maximum number objects that can be cached before pruning will take place
+  maxCacheSize=100000
+
+  # The following properties allow finer control over caching of Investigation sizes.
+  # Investigations can change size over time, so setting a lifetime on cached values may be useful.
+  # It may be useful not to cache zero-sized Investigations at all.
+  # IMPORTANT: size requests are also cached in the browser, so check settings in topcat.json too.
+
+  # Lifetime in seconds for cached Investigation sizes (default is 0, which means "immortal")
+  # investigationSizeCacheLifetimeSeconds=600
+
+  # Whether to cache zero-sized Investigations (default is false)
+  # neverCacheZeroSizedInvestigations=false
 ```
 
 $h2 topcat.json
@@ -224,6 +263,8 @@ If we expand the attributes in high level overview we can get a medium overview 
           "topcatUrl": "https://example.com",
           "home" : "my-data",
           "enableEuCookieLaw" : true,
+          "investigationSizeCacheLifetimeSeconds" : 0,
+          "dontCacheZeroSizedInvestigations": false,
           "paging" : {...},
           "breadcrumb": {...},
           "serviceStatus": {...},
@@ -260,6 +301,8 @@ from the above following attributes defined:
       * "topcatUrl" - the path to a valid Topcat REST API (optional).
       * "home" - the section the user gets redirected to after logging in can be "my-data", "browse" or "search"
       * "enableEuCookieLaw" - will show a cookie policy banner which the user can dismiss.
+      * "investigationSizeCacheLifetimeSeconds" - NEW in 2.4.2; if present and non-zero, the time after which browser-cached values for investigation sizes will be discarded
+      * "dontCacheZeroSizedInvestigations" - NEW in 2.4.2; if present and true, zero-sized investigations will not be cached in the browser.
       * "paging" - specifies the paging type configuration i.e. for either paged or infinite scroll
       * "breadcrumb" - specifies global breadcrumb options
       * "search" - specifies the structure of the search results and search fields for searching across facilities.

--- a/src/site/markdown/release-notes.md
+++ b/src/site/markdown/release-notes.md
@@ -4,6 +4,8 @@
 
 * improve DOI redirection failure message (issue #388)
 * mail configuration properties can be removed if not required (issue #389)
+* configurable control of caching behaviour for investigations (issue #394)
+* **database migration required** (simplest: drop the Cache table)
 
 ## 2.4.1
 

--- a/yo/app/config/topcat.json.example
+++ b/yo/app/config/topcat.json.example
@@ -5,6 +5,7 @@
         "enableEuCookieLaw" : true,
         "enableKiloBinaryBytes": false,
         "investigationSizeCacheLifetimeSeconds" : 0,
+        "dontCacheZeroSizedInvestigations": false,
         "paging" : {
             "pagingType": "scroll",
             "paginationNumberOfRows": 10,

--- a/yo/app/config/topcat.json.example
+++ b/yo/app/config/topcat.json.example
@@ -4,6 +4,7 @@
         "home" : "my-data",
         "enableEuCookieLaw" : true,
         "enableKiloBinaryBytes": false,
+        "investigationSizeCacheLifetimeSeconds" : 0,
         "paging" : {
             "pagingType": "scroll",
             "paginationNumberOfRows": 10,

--- a/yo/app/scripts/services/object-validator.service.js
+++ b/yo/app/scripts/services/object-validator.service.js
@@ -65,6 +65,7 @@
                     enableEuCookieLaw: { _type: 'boolean' },
                     enableKiloBinaryBytes: { _type: 'boolean',  _mandatory: false },
                     investigationSizeCacheLifetimeSeconds: { _type: 'number', _mandatory: false },
+                    dontCacheZeroSizedInvestigations: { _type: 'boolean',  _mandatory: false },
                     paging: { 
                         pagingType: { _type: 'string' },
                         paginationNumberOfRows: { _type: 'number' },

--- a/yo/app/scripts/services/object-validator.service.js
+++ b/yo/app/scripts/services/object-validator.service.js
@@ -64,6 +64,7 @@
                     home: { _type: 'string' },
                     enableEuCookieLaw: { _type: 'boolean' },
                     enableKiloBinaryBytes: { _type: 'boolean',  _mandatory: false },
+                    investigationSizeCacheLifetimeSeconds: { _type: 'number', _mandatory: false },
                     paging: { 
                         pagingType: { _type: 'string' },
                         paginationNumberOfRows: { _type: 'number' },

--- a/yo/app/scripts/services/tc-cache.service.js
+++ b/yo/app/scripts/services/tc-cache.service.js
@@ -23,7 +23,7 @@
            * @method
            * @name Cache#get
            * @param  {string} key the key by which the cached value is accessed
-           * @param  {number} seconds the length of time the cache tries to store the value for
+           * @param  {number} seconds the length of time the cache tries to store the value for (0 = forever)
            * @param  {Function} fn if no values has been cached it will run this function to create the value
            * @return {object}
            */
@@ -32,7 +32,11 @@
             var nowSeconds = (new Date).getTime() /  1000;
             var putSeconds = store.get("putSeconds:" + key);
 
-            if(out === undefined || (putSeconds && (nowSeconds - putSeconds) > seconds)){
+            // This condition needs some explanation! In essence, we want to store a new value:
+            // - if there is no value in the cache, or
+            // - if we specify an age limit but no age was stored, or
+            // - if we specify an age limit and it is too old
+            if(out === undefined || ((seconds > 0) && ((! putSeconds) || (nowSeconds - putSeconds) > seconds))){
               out = fn();
               store.put(key, out);
               if(seconds > 0){
@@ -119,7 +123,7 @@
            * @method
            * @name Cache#getPromise
            * @param  {string} key the key by which the cached value is accessed
-           * @param  {number} seconds the length of time the cache tries to store the value for
+           * @param  {number} seconds the length of time the cache tries to store the value for (0 = forever)
            * @param  {Function} fn if no values has been cached it will run this function to create a promise
            * @return {Promise<object>}
            */
@@ -131,7 +135,11 @@
 
             $rootScope.requestCounter++;
 
-            if(out === undefined || (putSeconds && (nowSeconds - putSeconds) > seconds)){
+            // This condition needs some explanation! In essence, we want to store a new value:
+            // - if there is no value in the cache, or
+            // - if we specify an age limit but no age was stored, or
+            // - if we specify an age limit and it is too old
+            if(out === undefined || ((seconds > 0) && ((! putSeconds) || (nowSeconds - putSeconds) > seconds))){
               fn().then(function(value){
                 store.put(key, value);
                 if(seconds > 0){

--- a/yo/app/scripts/services/tc-cache.service.js
+++ b/yo/app/scripts/services/tc-cache.service.js
@@ -4,7 +4,7 @@
 
     var app = angular.module('topcat');
 
-    app.service('tcCache', function($cacheFactory, $q, $timeout, $rootScope, helpers){
+    app.service('tcCache', function($cacheFactory, $q, $timeout, $rootScope, $interval, helpers){
 
       this.create = function(name,dontCache){
     	// console.log('tcCache: creating cache ' + name);
@@ -16,6 +16,44 @@
        */
       function Cache(name,dontCache){
         var store = $cacheFactory(name);
+        
+        // Code for monitoring
+        var monitoringOn = false;
+        
+        // Count promises whose value is already cached by the time they finish
+        var wastedPromises = 0;
+        var recentWastedPromises = 0;
+        
+        // Cache hits/misses (long- and short-term)
+        var hits = 0;
+        var misses = 0;
+        var recentHits = 0;
+        var recentMisses = 0;
+        
+        this.setMonitoring = function(flag){
+        	monitoringOn = flag;
+        }
+        
+        // Report cache stats every minute, reset every 10 mins
+        var statsResetCount = 0;
+	    $interval(function(){
+	        if( monitoringOn ){
+	        	if( hits > 0 || misses > 0 ){
+	        		console.log(`Cache: ${name}: ${recentHits}/${recentMisses} hits/misses (all time: ${hits}/${misses})`);
+	        	}
+	        	if( wastedPromises > 0 ){
+	        		console.log(`Cache: ${name}: ${recentWastedPromises} wasted promises (all time: ${wastedPromises})`);
+	        	}
+	        	if(statsResetCount++ == 10){
+	        		statsResetCount = 0;
+	            	console.log(`Cache: ${name}: resetting recent stats`);
+	            	recentHits = 0;
+	            	recentMisses = 0;
+	            	recentWastedPromises = 0;
+	        	}
+	        }
+        }, 1000 * 60);
+        
 
         this.get = helpers.overload({
           /**
@@ -38,6 +76,8 @@
             // - if we specify an age limit but no age was stored, or
             // - if we specify an age limit and it is too old
             if(out === undefined || ((seconds > 0) && ((! putSeconds) || (nowSeconds - putSeconds) > seconds))){
+            	misses++;
+            	recentMisses++;
             	out = fn();
             	if( ! (dontCache && dontCache(key,out)) ){
             		store.put(key, out);
@@ -45,6 +85,9 @@
             		  store.put("putSeconds:" + key, nowSeconds);
             		}
             	}
+            } else {
+            	hits++;
+            	recentHits++;
             }
             return out;
           },
@@ -143,7 +186,18 @@
             // - if we specify an age limit but no age was stored, or
             // - if we specify an age limit and it is too old
             if(out === undefined || ((seconds > 0) && ((! putSeconds) || (nowSeconds - putSeconds) > seconds))){
+              misses++;
+              recentMisses++;
               fn().then(function(value){
+            	if( monitoringOn ){
+            		  var out2 = store.get(key);
+            		  if( out2 && out2 == value ){
+            			  wastedPromises++;
+            			  recentWastedPromises++;
+            			  // Restore following to see when this happens
+            			  // console.log(`Cache: ${name}: wasted promise ${wastedPromises} for key ${key}`);
+            		  }
+            	}
                 if( ! (dontCache && dontCache(key,value)) ){
                 	store.put(key, value);
                 	if(seconds > 0){
@@ -157,6 +211,8 @@
                 defered.notify(results);
               });
             } else {
+            	hits++;
+            	recentHits++;
               defered.resolve(out);
             }
             

--- a/yo/app/scripts/services/tc-icat.service.js
+++ b/yo/app/scripts/services/tc-icat.service.js
@@ -484,7 +484,13 @@
                  */
                 'string, number, object': function(entityType, entityId, options){
                     var key = 'getSize:' + entityType + ":" + entityId;
-                    return this.cache().getPromise(key, function(){
+                    // Allow config to set a lifetime for Investigation entries - issue #394
+                    var lifetime = 0;
+                    if (entityType == 'investigation'){
+                    	var investigationLifetime = tc.config().investigationSizeCacheLifetimeSeconds;
+                	    lifetime = investigationLifetime ? investigationLifetime : 0;
+                    }
+                    return this.cache().getPromise(key, lifetime, function(){
                       var params = {
                         facilityName: facility.config().name,
                         sessionId: that.session().sessionId,

--- a/yo/app/scripts/services/tc-icat.service.js
+++ b/yo/app/scripts/services/tc-icat.service.js
@@ -19,8 +19,16 @@
             var cache;
             var tc = facility.tc();
 
+            // Set up a dontCache filter function for zero-sized investigations, if required
+            var dontCache = null
+            if(tc.config().dontCacheZeroSizedInvestigations){
+            	dontCache = function(key,value){
+            		return ( value == 0 && key.startsWith("getSize:investigation") );
+            	}
+            }
+            
             this.cache = function(){
-              if(!cache) cache = tcCache.create('icat:' + facility.config().name);
+              if(!cache) cache = tcCache.create('icat:' + facility.config().name,dontCache);
               return cache;
             };
 

--- a/yo/app/scripts/services/tc.service.js
+++ b/yo/app/scripts/services/tc.service.js
@@ -398,6 +398,11 @@
      */
     this.setMonitoring = function(aBool){
     	helpers.setLowPriorityQueueMonitoring(aBool);
+    	this.cache().setMonitoring(aBool);
+        _.each(this.facilities(), function(facility){
+            facility.icat().cache().setMonitoring(aBool);
+            facility.ids().cache().setMonitoring(aBool);
+          });
     	console.log('Topcat: monitoring set to ' + aBool);
     }
 

--- a/yo/app/scripts/services/tc.service.js
+++ b/yo/app/scripts/services/tc.service.js
@@ -387,6 +387,19 @@
       });
       $rootScope.$broadcast('global:refresh');
     };
+    
+    /**
+     * Enables/disables monitor reports in the browser console.
+     * When enabled, regular console messages show the max length and wait time for the low-priority queue.
+     * 
+     * @method
+     * @name tc#setMonitoring
+     * @param {bool} enable or disable monitoring
+     */
+    this.setMonitoring = function(aBool){
+    	helpers.setLowPriorityQueueMonitoring(aBool);
+    	console.log('Topcat: monitoring set to ' + aBool);
+    }
 
 		helpers.generateRestMethods(this, this.config().topcatUrl + "/topcat/");
 


### PR DESCRIPTION
The main changes here add optional configuration to (a) set a lifetime for cached investigation sizes and/or (b) never cache zero-sized investigations. Additional changes allow monitoring of the low-priority queue in the browser console (as this is used for getSize requests and can lead to inefficient use of the cache).
This fixes issue#394.
It may be useful to add REST methods to allow clients (e.g. an ingestion process) to explicitly update or clear cached size entries, but this should be a separate issue.
