### PR TITLE
Add DELETE clearSize to AdminResource

### DIFF
--- a/src/main/java/org/icatproject/topcat/repository/CacheRepository.java
+++ b/src/main/java/org/icatproject/topcat/repository/CacheRepository.java
@@ -69,6 +69,14 @@ public class CacheRepository {
 		em.persist(cache);
 		em.flush();
 	}
+	
+	public void remove(String key) {
+		Cache cache = getCache(key);
+		if( cache != null ){
+			em.remove(cache);
+		    em.flush();
+		}
+	}
 
 	@Schedule(hour="*", minute="0")
 	public void prune(){

--- a/src/test/java/org/icatproject/topcat/CacheRepositoryTest.java
+++ b/src/test/java/org/icatproject/topcat/CacheRepositoryTest.java
@@ -26,4 +26,16 @@ public class CacheRepositoryTest {
 		//assertEquals( "Hello World!", (String) cacheRepository.get("test:1"));
 	}
 
+	@Test
+	public void testRemove() {
+		// BR: this test requires the cacheRepository bean to be created,
+		// and I don't know how to do that. I don't think Jody did either,
+		// as all other tests that use cacheRepository have been commented-out!
+		/*
+		String key = "test:remove";
+		cacheRepository.put(key, "Hello World");
+		cacheRepository.remove(key);
+		assertEquals(null,cacheRepository.get(key));
+		*/
+	}
 }


### PR DESCRIPTION
AdminResource.clearCachedSize() uses a new method CacheRepository.remove().
I attempted to add a test to CacheRepository, but the test fails because the repository bean does not get set up. I don't know how to do that; and I note that all other tests that refer to the CacheRepository have all been commented-out.

Fixes #401.