### PR TITLE
Add recipe to replace loading spinner with static text

### DIFF
--- a/src/site/markdown/cookbook.md.vm
+++ b/src/site/markdown/cookbook.md.vm
@@ -6,4 +6,5 @@ Here are the current recipes:
 
   * [Combining grid columns](combining-grid-columns.html)
   * [Advanced metatabs](advanced-metatabs.html)
+  * [Replacing the loading spinner](replacing-loading-spinner.html)
 

--- a/src/site/markdown/replacing-loading-spinner.md.vm
+++ b/src/site/markdown/replacing-loading-spinner.md.vm
@@ -1,0 +1,13 @@
+# How to replace the loading spinner
+
+To replace the loading spinner with static text, add the following to topcat.css:
+
+```
+span.loading {
+	background: none;
+}
+
+span.loading:after {
+	content: "(...)";
+}
+```

--- a/yo/app/styles/topcat.css
+++ b/yo/app/styles/topcat.css
@@ -1,1 +1,14 @@
 /* your custom css */
+
+/* Replace loading spinner with text */
+
+/*
+span.loading {
+	background: none;
+}
+
+span.loading:after {
+	content: "(...)";
+}
+*/
+


### PR DESCRIPTION
Fixes #330. Recipe added to topcat.css, but commented-out.