### PR TITLE
#419 extra login buttons

### DIFF
--- a/src/site/markdown/installation.md.vm
+++ b/src/site/markdown/installation.md.vm
@@ -570,6 +570,27 @@ An example configuration:
   * plugin - a name that is used to programmatically reference the plugin on the Icat server.
   * showAsButton - optional boolean: if true, a separate login button is added for this authenticator.
 
+$h3 topcat.json: "facilities" > [facility] > "extraLoginButtons" 
+
+Optional. Specifies extra buttons to be added to the login page, as links to (possibly external) resources.
+For example, to add a button to register an account with the ISIS User Office:
+
+```
+{
+  "facilities": [
+    {
+            "extraLoginButtons": [
+                {
+                    "title": "Register",
+                    "url": "https://users.facilities.rl.ac.uk/auth/CreateAccount.aspx"
+                }
+            ],
+            ...
+    }
+  ]
+}
+```
+
 $h3 topcat.json: "facilities" > [facility] > "downloadTransportTypes" 
 
 Specifies the download delivery methods e.g. 'https' (via a browser) or 'globus' (a type of glorified ftp to deal with large files).

--- a/src/site/markdown/release-notes.md
+++ b/src/site/markdown/release-notes.md
@@ -4,6 +4,7 @@
 
   * Add optional preamble HTML to login page, defined in lang.json (issue #415)
   * Add showAsButton to authenticator configuration (in topcat.json) to give an authenticator its own login button (issue #418)
+  * Add extraLoginButtons to facility configuration (in topcat.json) (issue #419)
   
 ## 2.4.3 (25th Mar 2019)
 

--- a/yo/app/scripts/controllers/login.controller.js
+++ b/yo/app/scripts/controllers/login.controller.js
@@ -12,6 +12,7 @@
         this.nonUserFacilities = tc.nonUserFacilities();
         if(this.nonUserFacilities[0]) this.facilityName = this.nonUserFacilities[0].config().name;
         this.authenticationTypes = [];
+        this.extraButtons = [];
         this.buttonAuthTypes = [];
         this.userName = "";
         this.password = "";
@@ -100,6 +101,10 @@
         this.facilityChanged = function(){
             facility = tc.facility(this.facilityName);
             this.authenticationTypes = facility.config().authenticationTypes;
+            this.extraButtons = [];
+            if( facility.config().extraLoginButtons ){
+            	this.extraButtons = facility.config().extraLoginButtons;
+            }
             
             // Split authenticationTypes into those that have / don't have buttons
             this.buttonAuthTypes = _.select(this.authenticationTypes, function(authenticationType){return authenticationType.showAsButton;});

--- a/yo/app/scripts/services/object-validator.service.js
+++ b/yo/app/scripts/services/object-validator.service.js
@@ -193,6 +193,14 @@
                                 showAsButton: { _type: 'boolean', _mandatory: false  }
                             }
                         },
+                        extraLoginButtons: {
+                        	_type: 'array',
+                        	_item: {
+                        		title: { _type: 'string' },
+                        		url: { _type: 'string' }
+                        	},
+                        	_mandatory: false
+                        },
                         downloadTransportTypes: {
                             _type: 'array',
                             _mandatory: false,

--- a/yo/app/views/login.html
+++ b/yo/app/views/login.html
@@ -33,6 +33,9 @@
                         <span ng-repeat="authenticationType in loginController.buttonAuthTypes">
                             <button type="submit" class="btn btn-primary" ng-click="loginController.buttonLogin(authenticationType)" ng-disabled="loginController.requiresCreds(authenticationType) && loginController.form.$invalid">{{authenticationType.title}}</button>
                         </span>
+                        <span ng-repeat="extraButton in loginController.extraButtons">
+                            <a class="btn btn-primary" href="{{extraButton.url}}">{{extraButton.title}}</a>
+                        </span>
                     </div>
                 </fieldset>
             </form>


### PR DESCRIPTION
Add optional configuration to a facility in topcat.json to specify a list of extra buttons that will appear alongside the login button(s). Each button is specified by a title and a url.
Fixes #419.
