### PR TITLE
Issue#424 redirect handling

### DIFF
--- a/src/site/markdown/release-notes.md
+++ b/src/site/markdown/release-notes.md
@@ -5,6 +5,7 @@
   * Add optional preamble HTML to login page, defined in lang.json (issue #415)
   * Add showAsButton to authenticator configuration (in topcat.json) to give an authenticator its own login button (issue #418)
   * Add extraLoginButtons to facility configuration (in topcat.json) (issue #419)
+  * Remove DOI and some login redirections from browser history (issue #424)
   
 ## 2.4.3 (25th Mar 2019)
 

--- a/yo/app/scripts/app.js
+++ b/yo/app/scripts/app.js
@@ -542,6 +542,7 @@
     app.run(function ($rootScope, $state, $sessionStorage) {
         //store the last state
         $rootScope.$on('$stateChangeStart', function(event, toState, toParams){
+        	console.log("State Change: " + toState.name);
             if(!toState.name.match(/^(login|logout)/)){
                 $sessionStorage.lastState = {
                     name: toState.name,
@@ -552,8 +553,15 @@
 
         //listen for state change resolve authentication errors
         $rootScope.$on('$stateChangeError', function(event, toState, toParams, fromState, fromParams, error) {
+        	console.log("State Change Error: from " + fromState.name + " to: " + toState.name);
             if (error && error.isAuthenticated === false) {
-                $state.go('login');
+            	// Handle doi-redirection case specially
+            	if( toState.name == 'doi-redirect' ){
+            		console.log('doi-redirect needs login');
+            		$state.go('login',null,{location:'replace'});
+            	} else {
+            		$state.go('login');
+            	}
             }
         });
     });

--- a/yo/app/scripts/app.js
+++ b/yo/app/scripts/app.js
@@ -542,7 +542,6 @@
     app.run(function ($rootScope, $state, $sessionStorage) {
         //store the last state
         $rootScope.$on('$stateChangeStart', function(event, toState, toParams){
-        	console.log("State Change: " + toState.name);
             if(!toState.name.match(/^(login|logout)/)){
                 $sessionStorage.lastState = {
                     name: toState.name,
@@ -553,11 +552,9 @@
 
         //listen for state change resolve authentication errors
         $rootScope.$on('$stateChangeError', function(event, toState, toParams, fromState, fromParams, error) {
-        	console.log("State Change Error: from " + fromState.name + " to: " + toState.name);
             if (error && error.isAuthenticated === false) {
             	// Handle doi-redirection case specially
             	if( toState.name == 'doi-redirect' ){
-            		console.log('doi-redirect needs login');
             		$state.go('login',null,{location:'replace'});
             	} else {
             		$state.go('login');

--- a/yo/app/scripts/app.js
+++ b/yo/app/scripts/app.js
@@ -553,12 +553,10 @@
         //listen for state change resolve authentication errors
         $rootScope.$on('$stateChangeError', function(event, toState, toParams, fromState, fromParams, error) {
             if (error && error.isAuthenticated === false) {
-            	// Handle doi-redirection case specially
-            	if( toState.name == 'doi-redirect' ){
-            		$state.go('login',null,{location:'replace'});
-            	} else {
-            		$state.go('login');
-            	}
+            	// We set location:'replace' so that this redirection is removed from the browser history;
+            	// without this, the Back button cannot be used to get to the previous or earlier pages.
+            	// See issue #424 for further details.
+            	$state.go('login',null,{location:'replace'});
             }
         });
     });

--- a/yo/app/scripts/controllers/doi-redirect.controller.js
+++ b/yo/app/scripts/controllers/doi-redirect.controller.js
@@ -9,7 +9,11 @@
     	var facilityName = $state.params.facilityName;
     	var entityType = $state.params.entityType;
     	var entityId = $state.params.entityId;
-
+    	
+    	// We would like the eventual target to replace the original link in the browser history,
+    	// so that the Back button doesn't simply repeat the redirection.
+    	// Passing {location: 'replace'} as an option to the eventual call of $state.go() seems to work.
+    	
     	tc.icat(facilityName).query(["select ? from ? ? where ?.id = ", entityType.safe(), helpers.capitalize(entityType).safe(), entityType.safe(),entityType.safe(), entityId]).then(function(entities){
     		if( ! entities || ! entities[0] ){
     			// Query may return [] or null if the entity ID is unknown, [null] if user has no read access
@@ -30,10 +34,10 @@
     			});
     		} else if(entityType == 'datafile'){
     			entities[0].parent().then(function(entity){
-    				entity.browse();
+    				entity.browse({location:'replace'});
     			});
     		} else {
-    			entities[0].browse();
+    			entities[0].browse({location:'replace'});
     		}
     	});
     });

--- a/yo/app/scripts/controllers/index.controller.js
+++ b/yo/app/scripts/controllers/index.controller.js
@@ -27,6 +27,7 @@
         $rootScope.$on('http:error', function(){
             tc.purgeSessions().then(function(){
                 if(tc.userFacilities().length == 0 && tc.config().maintenanceMode && tc.config().maintenanceMode.show == false){
+                	console.log('Caught http:error, going to login state');
                     $state.go("login");
                 }
             });

--- a/yo/app/scripts/controllers/index.controller.js
+++ b/yo/app/scripts/controllers/index.controller.js
@@ -27,7 +27,6 @@
         $rootScope.$on('http:error', function(){
             tc.purgeSessions().then(function(){
                 if(tc.userFacilities().length == 0 && tc.config().maintenanceMode && tc.config().maintenanceMode.show == false){
-                	console.log('Caught http:error, going to login state');
                     $state.go("login");
                 }
             });

--- a/yo/app/scripts/controllers/logout.controller.js
+++ b/yo/app/scripts/controllers/logout.controller.js
@@ -33,7 +33,8 @@
         }
 
         $q.all(promises).then(function(){
-            $state.go('login');
+        	// Without location:replace browser Back button may not work - issue #424
+            $state.go('login',null,{location:'replace'});
         });
     });
 

--- a/yo/app/scripts/services/tc-icat-entity.service.js
+++ b/yo/app/scripts/services/tc-icat-entity.service.js
@@ -393,8 +393,9 @@
 			 * 
 			 * @method
 			 * @name IcatEntity#browse
+			 * @param {object} goOptions - passed to $state.go(); e.g. {location: 'replace'}, used by doi-redirection.
 			 */
-			this.browse = function(){
+			this.browse = function(goOptions){
 				var that = this;
 				this.stateParams().then(function(params){
 					var state = [];
@@ -404,7 +405,7 @@
 						if (('' + hierarchy[i - 1]).toLowerCase() == that.entityType.toLowerCase()) break;
 					}
 					state = "home.browse.facility." + state.join('-');
-					$state.go(state, params);
+					$state.go(state, params, goOptions);
 				});
 			};
 


### PR DESCRIPTION
Use location:'replace' in $state.go() to remove redirections from the browser history in several cases (doi-redirection, stateChangeError and logout redirection to the login page).

Fixes #424.