### PR TITLE
Issue#349 ids timeout units

### DIFF
--- a/src/main/config/topcat.properties.example
+++ b/src/main/config/topcat.properties.example
@@ -75,3 +75,9 @@ maxCacheSize=100000
 
 # Whether to cache zero-sized Investigations (default is false)
 # neverCacheZeroSizedInvestigations=false
+
+# Timeout for IDS connections.
+# Optional (default is no timeout). Can be in seconds (suffix 's'), minutes ('m') or milliseconds (no suffix)
+# ids.timeout=180000
+# ids.timeout=180s
+# ids.timeout=3m

--- a/src/site/markdown/installation.md.vm
+++ b/src/site/markdown/installation.md.vm
@@ -127,6 +127,11 @@ In this case, mail.enable in topcat.properties MUST NOT be set to true. This is 
 
 $h2 topcat.properties
 
+$h3 New in 2.4.4
+
+The `ids.timeout` property can now have an optional `s` or `m` suffix to specify seconds or minutes.
+The default remains milliseconds (so existing configurations do not need to be changed).
+
 $h3 New properties in 2.4.2
 
 New properties have been added to allow finer control over caching of Investigation sizes.
@@ -236,6 +241,12 @@ Note: '#'s are comments.
 
   # Whether to cache zero-sized Investigations (default is false)
   # neverCacheZeroSizedInvestigations=false
+  
+  # Timeout for IDS connections.
+  # Optional (default is no timeout). Can be in seconds (suffix 's'), minutes ('m') or milliseconds (no suffix)
+  # ids.timeout=180000
+  # ids.timeout=180s
+  # ids.timeout=3m
 ```
 
 $h2 topcat.json

--- a/src/site/markdown/release-notes.md
+++ b/src/site/markdown/release-notes.md
@@ -6,6 +6,7 @@
   * Add showAsButton to authenticator configuration (in topcat.json) to give an authenticator its own login button (issue #418)
   * Add extraLoginButtons to facility configuration (in topcat.json) (issue #419)
   * Remove DOI and some login redirections from browser history (issue #424)
+  * Allow ids.timeout to be in seconds or minutes as well as milliseconds (issue #349)
   
 ## 2.4.3 (25th Mar 2019)
 

--- a/src/test/java/org/icatproject/topcat/IdsClientTest.java
+++ b/src/test/java/org/icatproject/topcat/IdsClientTest.java
@@ -65,6 +65,19 @@ public class IdsClientTest {
 		assertTrue("expected: " + expected + " actual: " + actual, expected.equals(actual));
 
 	}
+	
+	@Test
+	public void testParseTimeout() throws Exception {
+		IdsClient idsClient = new IdsClient("https://localhost:8181");
+		Method parseTimeout = idsClient.getClass().getDeclaredMethod("parseTimeout", String.class);
+		parseTimeout.setAccessible(true);
+		
+		assertEquals(parseTimeout.invoke(idsClient, "1000"), 1000);
+		assertEquals(parseTimeout.invoke(idsClient, "10s"), 10000);
+		assertEquals(parseTimeout.invoke(idsClient, "10m"), 600000);
+		assertEquals(parseTimeout.invoke(idsClient, "-1"), -1);
+		assertEquals(parseTimeout.invoke(idsClient, "rubbish"), -1);
+	}
 
 	private List<Long> generateIds(int offset, int count){
 		List<Long> out = new ArrayList<Long>();


### PR DESCRIPTION
The value of ids.timeout can now have an optional 's' or 'm' suffix, that interprets the numeric value as seconds or minutes rather than milliseconds (which remains the default).

Fixes #349.
