### PR TITLE
Issue#439 handle failed get size requests

### DIFF
--- a/src/site/markdown/release-notes.md
+++ b/src/site/markdown/release-notes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 2.4.5-SNAPSHOT
+
+  * Improve feedback when getSize requests fail (issue #439)
+  
 ## 2.4.4 (1st Jul 2019)
 
   * Add optional preamble HTML to login page, defined in lang.json (issue #415)

--- a/yo/app/scripts/controllers/download-cart.controller.js
+++ b/yo/app/scripts/controllers/download-cart.controller.js
@@ -82,6 +82,10 @@
                     cart.getSize(timeout.promise).then(function(size){
                         download.size = size;
                         download.estimatedTime = Math.ceil(size);
+                    }, function(response){
+                    	// getSize failed (will be logged from elsewhere); use -1 for "unknown"
+                    	download.size = -1;
+                    	download.estimatedTime = -1;
                     });
 
                     that.downloads.push(download);

--- a/yo/app/scripts/controllers/meta-panel.controller.js
+++ b/yo/app/scripts/controllers/meta-panel.controller.js
@@ -66,7 +66,7 @@
                     }
 
                     if(field == 'size'){   
-                        item.template = '<span><span ng-if="item.entity.isGettingSize && $root.requestCounter != 0" class="loading collapsed">&nbsp;</span>{{item.entity.size|bytes}}<button class="btn btn-default btn-xs" ng-click="meta.getSize(item.entity)" ng-if="!item.entity.isGettingSize && item.entity.size === undefined">Calculate</button></span>';
+                        item.template = '<span><span ng-if="item.entity.isGettingSize && $root.requestCounter != 0" class="loading collapsed">&nbsp;</span><span ng-if="item.entity.size == -1">Unknown</span><span ng-if="item.entity.size != -1">{{item.entity.size|bytes}}</span><button class="btn btn-default btn-xs" ng-click="meta.getSize(item.entity)" ng-if="!item.entity.isGettingSize && item.entity.size === undefined">Calculate</button></span>';
                     }
 
                     if(!item.label && item.label !== ''){

--- a/yo/app/scripts/controllers/meta-panel.controller.js
+++ b/yo/app/scripts/controllers/meta-panel.controller.js
@@ -66,7 +66,7 @@
                     }
 
                     if(field == 'size'){   
-                        item.template = '<span><span ng-if="item.entity.isGettingSize && $root.requestCounter != 0" class="loading collapsed">&nbsp;</span><span ng-if="item.entity.size == -1">Unknown</span><span ng-if="item.entity.size != -1">{{item.entity.size|bytes}}</span><button class="btn btn-default btn-xs" ng-click="meta.getSize(item.entity)" ng-if="!item.entity.isGettingSize && item.entity.size === undefined">Calculate</button></span>';
+                        item.template = '<span><span ng-if="item.entity.isGettingSize && $root.requestCounter != 0" class="loading collapsed">&nbsp;</span><span ng-if="item.entity.size == -1">Unknown</span><span ng-if="item.entity.size && item.entity.size != -1">{{item.entity.size|bytes}}</span><button class="btn btn-default btn-xs" ng-click="meta.getSize(item.entity)" ng-if="!item.entity.isGettingSize && item.entity.size === undefined">Calculate</button></span>';
                     }
 
                     if(!item.label && item.label !== ''){

--- a/yo/app/scripts/services/helpers.service.js
+++ b/yo/app/scripts/services/helpers.service.js
@@ -70,7 +70,7 @@
 
             if(field === 'size') {
 
-                columnDef.cellTemplate = columnDef.cellTemplate || '<div class="ui-grid-cell-contents"><span ng-if="row.entity.size === undefined && $root.requestCounter != 0" class="loading">&nbsp;</span>{{row.entity.size|bytes}}</div>';
+                columnDef.cellTemplate = columnDef.cellTemplate || '<div class="ui-grid-cell-contents"><span ng-if="row.entity.size === undefined && $root.requestCounter != 0" class="loading">&nbsp;</span><span ng-if="row.entity.size == -1">Unknown</span><span ng-if="row.entity.size != -1">{{row.entity.size|bytes}}</span></div>';
             	columnDef.enableSorting = false;
                 columnDef.enableFiltering = false;
             }

--- a/yo/app/scripts/services/tc-icat-entity.service.js
+++ b/yo/app/scripts/services/tc-icat-entity.service.js
@@ -110,8 +110,12 @@
 							that.isGettingSize = false;
 							return size;
 						}, function(response){
-                        	// error handler - getSize request failed
-                        	console.log(that.entityType + ' entity getSize failed: ' + response.code + ", " + response.message);
+                        	// error handler - getSize request failed; use -1 as "unknown size"
+							var msg = response?' entity getSize failed: ' + response.code + ", " + response.message : ' response is null';
+                        	console.log(that.entityType + msg);
+                        	that.size = -1;
+                        	that.isGettingSize = false;
+                        	return -1;
                         });
 					},
 

--- a/yo/app/scripts/services/tc-icat-entity.service.js
+++ b/yo/app/scripts/services/tc-icat-entity.service.js
@@ -109,7 +109,10 @@
 							that.size = size;
 							that.isGettingSize = false;
 							return size;
-						});
+						}, function(response){
+                        	// error handler - getSize request failed
+                        	console.log(that.entityType + ' entity getSize failed: ' + response.code + ", " + response.message);
+                        });
 					},
 
 					/**

--- a/yo/app/scripts/services/tc-user-cart.service.js
+++ b/yo/app/scripts/services/tc-user-cart.service.js
@@ -55,11 +55,15 @@
 
                     helpers.throttle(10, 1, options.timeout, this.cartItems, function(cartItem){
                         return facility.icat().getSize(cartItem.entityType, cartItem.entityId,options).then(function(size){
-                            out += size;
+                        	// Don't change total if getSize for some other cartItem has failed
+                            if(out != -1 ) out += size;
                             defered.notify(out);
                         }, function(response){
                         	// error handler - getSize request failed
-                        	console.log('cart item getSize failed: ' + response.code + ", " + response.message);
+                        	var msg = response?' entity getSize failed: ' + response.code + ", " + response.message : ' response is null';
+                        	console.log('cart item getSize failed: ' + msg);
+                        	// use -1 for "size unknown"
+                        	out = -1
                         	defered.reject(response);
                         });
                     }).then(function(){

--- a/yo/app/scripts/services/tc-user-cart.service.js
+++ b/yo/app/scripts/services/tc-user-cart.service.js
@@ -57,6 +57,10 @@
                         return facility.icat().getSize(cartItem.entityType, cartItem.entityId,options).then(function(size){
                             out += size;
                             defered.notify(out);
+                        }, function(response){
+                        	// error handler - getSize request failed
+                        	console.log('cart item getSize failed: ' + response.code + ", " + response.message);
+                        	defered.reject(response);
                         });
                     }).then(function(){
                         defered.notify(out);

--- a/yo/app/views/download-cart.html
+++ b/yo/app/views/download-cart.html
@@ -30,10 +30,10 @@
                         <div ng-if="download.transportType.description">{{download.transportType.description}}</div>
                     </td>
                     <td>
-                        <span ng-if="download.size === undefined" class="loading collapsed"></span><span>{{download.size | bytes}}</span>
+                        <span ng-if="download.size === undefined" class="loading collapsed"></span><span ng-if="download.size == -1">Unknown</span><span ng-if="download.size != -1">{{download.size | bytes}}</span>
                     </td>
                     <td>
-                        <span ng-if="download.size === undefined" class="loading collapsed"></span><span>{{download.estimatedTime / downloadCartController.connectionSpeed | timeLength}}</span>
+                        <span ng-if="download.size === undefined" class="loading collapsed"></span><span ng-if="download.size == -1">Unknown</span><span ng-if="download.size != -1">{{download.estimatedTime / downloadCartController.connectionSpeed | timeLength}}</span>
                     <td ng-if="downloadCartController.facilityCount > 1">
                         <span>{{download.facilityName}}</span>
                     </td>


### PR DESCRIPTION
Failed getSize requests are now logged in the browser console, and set the result to -1.
Templates show a size of -1 as "Unknown".
Metapanel size fields no longer show as "0 B" before they have been calculated.

Fixes #439 
