### PR TITLE
Issue#443 doi anon login

### DIFF
--- a/src/site/markdown/installation.md.vm
+++ b/src/site/markdown/installation.md.vm
@@ -604,6 +604,31 @@ For example, to add a button to register an account with the ISIS User Office:
 }
 ```
 
+$h3 topcat.json: "facilities" > [facility] > "doiAutoLoginAuth"
+
+Optional. Specifies the authentication method and credentials to be used (if requested) by DOI redirections.
+Defaults to the "anon" authenticator (in which case it must be available and supported by the ICAT instance).
+Note that the configuration can be inspected by users in the browser console, so setting this is NOT RECOMMENDED
+for production systems. (Its main use is for development, where the LILS facility does not support anonymous
+authentication.)
+
+```
+{
+  "facilities": [
+    {
+            "doiAutoLoginAuth": {
+            	"plugin": "simple",
+            	"credentials": {
+            		"username": "root",
+            		"password": "vegetable"
+            	}
+            },
+            ...
+    }
+  ]
+}
+```
+
 $h3 topcat.json: "facilities" > [facility] > "downloadTransportTypes" 
 
 Specifies the download delivery methods e.g. 'https' (via a browser) or 'globus' (a type of glorified ftp to deal with large files).

--- a/src/site/markdown/release-notes.md
+++ b/src/site/markdown/release-notes.md
@@ -4,6 +4,7 @@
 
   * Improve feedback when getSize requests fail (issue #439)
   * Fix Sample inclusions in metapanel queries (issue #441)
+  * Allow automatic (anonymous) login for DOI redirect requests (issue #443)
   
 ## 2.4.4 (1st Jul 2019)
 

--- a/yo/app/scripts/app.js
+++ b/yo/app/scripts/app.js
@@ -484,7 +484,18 @@
                 controller: 'DoiRedirectController',
                 resolve: {
                     authenticate : ['Authenticate', function(Authenticate) {
-                        return Authenticate.authenticate();
+                    	return Authenticate.authenticate();
+                    }]
+                }
+            })
+            .state('doi-redirect-anon', {
+                url: '/doi-redirect/:facilityName/:entityType/:entityId/:anonLogin',
+                controller: 'DoiRedirectController',
+                resolve: {
+                    authenticate : ['Authenticate', function(Authenticate) {
+                    	// TEST
+                        // return Authenticate.authenticate();
+                    	return true;
                     }]
                 }
             });
@@ -556,6 +567,14 @@
             	// We set location:'replace' so that this redirection is removed from the browser history;
             	// without this, the Back button cannot be used to get to the previous or earlier pages.
             	// See issue #424 for further details.
+            	console.log("app.js: stateChangeError isAuthenticated false (" + toState.name + "," + fromState.name + ")");
+            	console.log("Params: " + toParams.facilityName + "," + toParams.entityType + "," + toParams.entityId);
+            	if( toState.name === 'doi-redirect' && toParams.anonLogin ){
+            		// At this point we should do an "automatic" login using the Anon authenticator
+            		// instead of going to the login dialog/state.
+            		// ... but I don't know how to do that here!
+            		console.log("Doi-redirect: auto login requested (TODO)");
+            	}
             	$state.go('login',null,{location:'replace'});
             }
         });

--- a/yo/app/scripts/app.js
+++ b/yo/app/scripts/app.js
@@ -489,12 +489,12 @@
                 }
             })
             .state('doi-redirect-anon', {
+            	// doi-redirect variant: if anonLogin is true (and not already logged in), will request (anon) login first
                 url: '/doi-redirect/:facilityName/:entityType/:entityId/:anonLogin',
                 controller: 'DoiRedirectController',
                 resolve: {
                     authenticate : ['Authenticate', function(Authenticate) {
-                    	// TEST
-                        // return Authenticate.authenticate();
+                    	// Bypass authentication testing in case anon login is requested
                     	return true;
                     }]
                 }
@@ -567,14 +567,6 @@
             	// We set location:'replace' so that this redirection is removed from the browser history;
             	// without this, the Back button cannot be used to get to the previous or earlier pages.
             	// See issue #424 for further details.
-            	console.log("app.js: stateChangeError isAuthenticated false (" + toState.name + "," + fromState.name + ")");
-            	console.log("Params: " + toParams.facilityName + "," + toParams.entityType + "," + toParams.entityId);
-            	if( toState.name === 'doi-redirect' && toParams.anonLogin ){
-            		// At this point we should do an "automatic" login using the Anon authenticator
-            		// instead of going to the login dialog/state.
-            		// ... but I don't know how to do that here!
-            		console.log("Doi-redirect: auto login requested (TODO)");
-            	}
             	$state.go('login',null,{location:'replace'});
             }
         });

--- a/yo/app/scripts/controllers/doi-redirect.controller.js
+++ b/yo/app/scripts/controllers/doi-redirect.controller.js
@@ -5,40 +5,62 @@
 
     var app = angular.module('topcat');
 
-    app.controller('DoiRedirectController', function($state, $translate, inform, tc, helpers){
+    app.controller('DoiRedirectController', function($state, $translate, $q, inform, tc, helpers){
     	var facilityName = $state.params.facilityName;
     	var entityType = $state.params.entityType;
     	var entityId = $state.params.entityId;
+    	var anonLogin = $state.params.anonLogin;
+    	
+    	var optionalLoginPromise = $q.when();
+    	
+    	// TEST
+    	console.log("doi-redirect starting...");
+    	if( ! tc.icat(facilityName).session().sessionId ){
+    		var msg = "doi-redirect: no sessionId for " + facilityName;
+    		console.log(msg);
+			inform.add(msg, {
+				'ttl' : -1,
+				'type' : 'warning'
+			});
+			if( anonLogin ){
+				console.log("doi-redirect: anonLogin set, so auto-login as Anon (TODO - try simple root for now)");
+				optionalLoginPromise = tc.icat(facilityName).login('simple',{'username':'root','password':'root'});
+			}
+    	} else {
+    		console.log("doi-redirect: have sessionId - but is it any good?");
+    	}
     	
     	// We would like the eventual target to replace the original link in the browser history,
     	// so that the Back button doesn't simply repeat the redirection.
     	// Passing {location: 'replace'} as an option to the eventual call of $state.go() seems to work.
     	
-    	tc.icat(facilityName).query(["select ? from ? ? where ?.id = ", entityType.safe(), helpers.capitalize(entityType).safe(), entityType.safe(),entityType.safe(), entityId]).then(function(entities){
-    		if( ! entities || ! entities[0] ){
-    			// Query may return [] or null if the entity ID is unknown, [null] if user has no read access
-    			// In these cases, inform the user.
-    			// We could go to the default home page in this case, but BR prefers to leave the page blank.
-    			// If we *do* set a particular state, it has to happen before the inform.
-    			// var state = tc.config().home == 'browse' ? 'home.browse.facility' : 'home.' + tc.config().home;
-    	        // $state.go(state);
-    			var msg = $translate.instant("DOI.QUERY_EMPTY");
-    			if( msg != "DOI.QUERY_EMPTY" ){
-    				msg = msg.replace(/_ENTITY_TYPE_/g,entityType);
-    			} else {
-    				msg = "Cannot read the " + entityType + ". You may not have read access, or it may not be published yet.";
-    			}
-    			inform.add(msg, {
-    				'ttl' : -1,
-    				'type' : 'warning'
-    			});
-    		} else if(entityType == 'datafile'){
-    			entities[0].parent().then(function(entity){
-    				entity.browse({location:'replace'});
-    			});
-    		} else {
-    			entities[0].browse({location:'replace'});
-    		}
+    	optionalLoginPromise.then(function() {
+	    	tc.icat(facilityName).query(["select ? from ? ? where ?.id = ", entityType.safe(), helpers.capitalize(entityType).safe(), entityType.safe(),entityType.safe(), entityId]).then(function(entities){
+	    		if( ! entities || ! entities[0] ){
+	    			// Query may return [] or null if the entity ID is unknown, [null] if user has no read access
+	    			// In these cases, inform the user.
+	    			// We could go to the default home page in this case, but BR prefers to leave the page blank.
+	    			// If we *do* set a particular state, it has to happen before the inform.
+	    			// var state = tc.config().home == 'browse' ? 'home.browse.facility' : 'home.' + tc.config().home;
+	    	        // $state.go(state);
+	    			var msg = $translate.instant("DOI.QUERY_EMPTY");
+	    			if( msg != "DOI.QUERY_EMPTY" ){
+	    				msg = msg.replace(/_ENTITY_TYPE_/g,entityType);
+	    			} else {
+	    				msg = "Cannot read the " + entityType + ". You may not have read access, or it may not be published yet.";
+	    			}
+	    			inform.add(msg, {
+	    				'ttl' : -1,
+	    				'type' : 'warning'
+	    			});
+	    		} else if(entityType == 'datafile'){
+	    			entities[0].parent().then(function(entity){
+	    				entity.browse({location:'replace'});
+	    			});
+	    		} else {
+	    			entities[0].browse({location:'replace'});
+	    		}
+	    	})
     	});
     });
 

--- a/yo/app/scripts/controllers/doi-redirect.controller.js
+++ b/yo/app/scripts/controllers/doi-redirect.controller.js
@@ -22,9 +22,15 @@
 				console.log("doi-redirect: anonLogin set, so auto-login");
 				// This should be configurable, or hard-wired to the anon authenticator;
 				// (ICAT for) LILS is not set up for anon, so hard-wire simple auth instead
-				var authName = 'simple';
-				var credentials = {'username':'root','password':'root'};
-				optionalLoginPromise = tc.icat(facilityName).login(authName,credentials);
+				var doiAuth = tc.facility(facilityName).config().doiAutoLoginAuth;
+				if( ! doiAuth ){
+					console.log("doi-redirect: no doi authentication configured, so assume anon");
+					doiAuth = {
+						plugin: "anon",
+						credentials: {}
+					}
+				};
+				optionalLoginPromise = tc.icat(facilityName).login(doiAuth.plugin,doiAuth.credentials);
 			}
     	}
     	

--- a/yo/app/scripts/controllers/doi-redirect.controller.js
+++ b/yo/app/scripts/controllers/doi-redirect.controller.js
@@ -18,7 +18,7 @@
     	
     	if( ! tc.icat(facilityName).session().sessionId ){
     		console.log("doi-redirect: no sessionId for " + facilityName);
-			if( anonLogin ){
+			if( anonLogin === 'true'){
 				console.log("doi-redirect: anonLogin set, so auto-login");
 				// This should be configurable, or hard-wired to the anon authenticator;
 				// (ICAT for) LILS is not set up for anon, so hard-wire simple auth instead

--- a/yo/app/scripts/controllers/doi-redirect.controller.js
+++ b/yo/app/scripts/controllers/doi-redirect.controller.js
@@ -9,25 +9,23 @@
     	var facilityName = $state.params.facilityName;
     	var entityType = $state.params.entityType;
     	var entityId = $state.params.entityId;
+    	
+    	// anonLogin (boolean) will only be set in some cases
     	var anonLogin = $state.params.anonLogin;
     	
+    	// By default, use an "empty" promise rather than logging in
     	var optionalLoginPromise = $q.when();
     	
-    	// TEST
-    	console.log("doi-redirect starting...");
     	if( ! tc.icat(facilityName).session().sessionId ){
-    		var msg = "doi-redirect: no sessionId for " + facilityName;
-    		console.log(msg);
-			inform.add(msg, {
-				'ttl' : -1,
-				'type' : 'warning'
-			});
+    		console.log("doi-redirect: no sessionId for " + facilityName);
 			if( anonLogin ){
-				console.log("doi-redirect: anonLogin set, so auto-login as Anon (TODO - try simple root for now)");
-				optionalLoginPromise = tc.icat(facilityName).login('simple',{'username':'root','password':'root'});
+				console.log("doi-redirect: anonLogin set, so auto-login");
+				// This should be configurable, or hard-wired to the anon authenticator;
+				// (ICAT for) LILS is not set up for anon, so hard-wire simple auth instead
+				var authName = 'simple';
+				var credentials = {'username':'root','password':'root'};
+				optionalLoginPromise = tc.icat(facilityName).login(authName,credentials);
 			}
-    	} else {
-    		console.log("doi-redirect: have sessionId - but is it any good?");
     	}
     	
     	// We would like the eventual target to replace the original link in the browser history,

--- a/yo/app/scripts/services/object-validator.service.js
+++ b/yo/app/scripts/services/object-validator.service.js
@@ -201,6 +201,14 @@
                         	},
                         	_mandatory: false
                         },
+                        doiAutoLoginAuth: {
+                        	plugin: { _type: 'string' },
+                        	credentials: {
+                        		username: { _type: 'string' },
+                        		password: { _type: 'string' }
+                        	},
+                        	_mandatory: false
+                        },
                         downloadTransportTypes: {
                             _type: 'array',
                             _mandatory: false,


### PR DESCRIPTION
Fixes #443 

Automatic (anonymous) login from DOI landing-page links

The solution I have chosen is: if the doi-redirect URL includes an extra parameter with the value "true", e.g.:

    `http://localhost:10080/#/doi-redirect/LILS/investigation/49/true`

then Topcat will perform an initial login using anonymous authentication. If this is successful, then the user should be presented with the browse page for the entity specified by the entity type and id.

For this to work, the anonymous authenticator must be installed, the plugin name must be "auth"; and ICAT must be configured to allow appropriate access.

If the parameter is missing (as in current DOI links, which will still work), or is set to any value other than "true", auto-login will not be attempted; normally, this means that the user will be presented with Topcat's login page.

To support installations that do not have anonymous authentication but still required automatic login, it is possible to define an alternative authenticator in the configuration. See the installation notes for more details on how to do this.  Note that this exposes the authenticator credentials to the user's browser, so is not recommended; the main motivation is to support the LILS development facility (set up by Vagrant) whose ICAT is not configured for anonymous access.
