### PR TITLE
More server-side tests

### DIFF
--- a/provision/authn_simple.properties
+++ b/provision/authn_simple.properties
@@ -3,7 +3,8 @@
 
 # Space separated list of user names that this plugin authenticates.
 !user.list = usera userb userc userd usere
-user.list = root
+# The nonroot user has no rights in ICAT; it is added here to test the Topcat AdminResource API
+user.list = root nonroot
 
 # Password for each user.  This may either be a clear text password or
 # a cryptographic hash of a password.
@@ -16,6 +17,7 @@ user.list = root
 #
 # A clear text password must not start with a '$' character.
 user.root.password = root
+user.nonroot.password = nonroot
 !user.usera.password =  passworda
 !user.userb.password =  $1$kK4p1s9W$pLp9/FS.HI6RF3sINY3X20
 !user.userc.password =  $5$rOcFOsg2dEk5$fB15Q6sbW0TAAlngkHmciuep59G.EcDng81nawJ.9f1

--- a/src/main/java/org/icatproject/topcat/repository/DownloadRepository.java
+++ b/src/main/java/org/icatproject/topcat/repository/DownloadRepository.java
@@ -100,4 +100,11 @@ public class DownloadRepository {
 		return store;
 	}
 
+	public void removeDownload(Long id) {
+	    Download download = em.find(Download.class, id);
+	    if( download != null ){
+	        em.remove(download);
+		em.flush();
+	    }
+	}
 }

--- a/src/test/java/org/icatproject/topcat/AdminResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/AdminResourceTest.java
@@ -1,0 +1,278 @@
+package org.icatproject.topcat;
+
+import java.util.*;
+import java.io.File;
+import java.lang.reflect.*;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+import static org.junit.Assert.*;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import javax.inject.Inject;
+
+import javax.json.*;
+import javax.ws.rs.core.Response;
+import javax.ejb.EJB;
+
+import org.icatproject.topcat.httpclient.HttpClient;
+import org.icatproject.topcat.domain.*;
+import org.icatproject.topcat.exceptions.BadRequestException;
+
+import java.net.URLEncoder;
+
+import org.icatproject.topcat.repository.CacheRepository;
+import org.icatproject.topcat.repository.ConfVarRepository;
+import org.icatproject.topcat.repository.DownloadRepository;
+import org.icatproject.topcat.repository.DownloadTypeRepository;
+import org.icatproject.topcat.web.rest.AdminResource;
+
+import java.sql.*;
+
+@RunWith(Arquillian.class)
+public class AdminResourceTest {
+
+	/*
+	 * CURRENT STATUS:
+	 * I can only get this to work if I put a cobbled copy of topcat.properties in the root folder.
+	 * All attempts to use addAsResource() have failed, and I'm fed up trying to guess (from several million online examples) how it should be used correctly!
+	 *
+	 * Of course, these are not unit tests, but use an embedded container and a local ICAT/IDS which we assume to be populated appropriately.
+	 */
+	
+    @Deployment
+    public static JavaArchive createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class)
+            .addClasses(AdminResource.class, CacheRepository.class, DownloadRepository.class, DownloadTypeRepository.class, ConfVarRepository.class)
+            .addPackages(true,"org.icatproject.topcat.domain","org.icatproject.topcat.exceptions")
+            .addAsResource("META-INF/persistence.xml")
+            // .addAsResource("topcat.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+	@EJB
+	private DownloadRepository downloadRepository;
+
+	@EJB
+	private DownloadTypeRepository downloadTypeRepository;
+
+    @EJB
+    private ConfVarRepository confVarRepository;
+
+	@EJB
+	private CacheRepository cacheRepository;
+	
+	@Inject
+	private AdminResource adminResource;
+
+	private static String adminSessionId;
+	private static String nonAdminSessionId;
+
+	@Before
+	public void setup() throws Exception {
+		TestHelpers.installTrustManager();
+
+		HttpClient httpClient = new HttpClient("https://localhost:8181/icat");
+		
+		// Log in as an admin user
+		
+		String data = "json=" + URLEncoder.encode("{\"plugin\":\"simple\", \"credentials\":[{\"username\":\"root\"}, {\"password\":\"root\"}]}", "UTF8");
+		String response = httpClient.post("session", new HashMap<String, String>(), data).toString();
+		adminSessionId = Utils.parseJsonObject(response).getString("sessionId");
+		
+		// TODO: log in as a non-admin user - would have to add one first!
+
+	}
+
+	@Test
+	public void testIsValidSession() throws Exception {
+		String facilityName = "LILS";
+		Response response;
+		
+		// Should be true for an admin user
+		
+		response = adminResource.isValidSession(facilityName, adminSessionId);
+		assertEquals(200, response.getStatus());
+		assertEquals("true", (String)response.getEntity());
+		
+		// TODO Should be false for a non-admin (but valid) user
+		
+		// Request should fail for a nonsense sessionId
+		response = adminResource.isValidSession(facilityName, "nonsense id");
+		// Expected this to raise a BadRequestException, but surprisingly it doesn't
+		assertEquals(200, response.getStatus());
+		assertEquals("false", (String)response.getEntity());
+	}
+	
+	@Test
+	public void testDownloadAPI() throws Exception {
+		String facilityName = "LILS";
+		Response response;
+		JsonObject json;
+		List<Download> downloads;
+		
+		// Get the current downloads - may not be empty
+		// It appears queryOffset cannot be empty!
+		String queryOffset = "1 = 1";
+		response = adminResource.getDownloads(facilityName, adminSessionId, queryOffset);
+		assertEquals(200, response.getStatus());
+		
+		downloads = (List<Download>)response.getEntity();
+		
+		// Check that the result tallies with the DownloadRepository contents
+		
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("queryOffset", queryOffset);
+        List<Download> repoDownloads = new ArrayList<Download>();
+		repoDownloads = downloadRepository.getDownloads(params);
+		
+		assertEquals( repoDownloads.size(), downloads.size() );
+		for( Download download : repoDownloads ) {
+			assertNotNull( findDownload(downloads,download.getId()));
+		}
+		
+		// Choose a download to manipulate. (Really, we should create a dummy one!)
+		
+		Download download = downloads.get(0);
+		
+		// Next, change the download status. Must be different from the current status!
+		String downloadStatus = "EXPIRED";
+		if( download.getStatus().equals(DownloadStatus.valueOf(downloadStatus))) {
+			downloadStatus = "PAUSED";
+		}
+		
+		response = adminResource.setDownloadStatus(download.getId(), facilityName, adminSessionId, downloadStatus);
+		assertEquals(200, response.getStatus());
+		
+		// and test that the new status has been set
+		
+		response = adminResource.getDownloads(facilityName, adminSessionId, queryOffset);
+		assertEquals(200, response.getStatus());
+		downloads = (List<Download>)response.getEntity();
+		
+		download = findDownload(downloads,download.getId());
+		
+		// To be thorough, we ought to check that ONLY the status field has changed. Not going to!
+		assertEquals( DownloadStatus.valueOf(downloadStatus), download.getStatus() );
+		
+		// Now toggle the deleted status - may have been deleted already!
+		Boolean currentDeleted = download.getIsDeleted();
+		
+		response = adminResource.deleteDownload(download.getId(), facilityName, adminSessionId, ! currentDeleted);
+		assertEquals(200, response.getStatus());
+		
+		// and check that it has worked (again, not bothering to check that nothing else has changed)
+		
+		response = adminResource.getDownloads(facilityName, adminSessionId, queryOffset);
+		assertEquals(200, response.getStatus());
+		downloads = (List<Download>)response.getEntity();
+		
+		download = findDownload(downloads,download.getId());
+		assertTrue( download.getIsDeleted() != currentDeleted );
+		
+		// TODO: test that getDownloadStatus() produces an error response for a non-admin user
+	}
+	
+	@Test
+	public void testSetDownloadTypeStatus() throws Exception {
+
+		String facilityName = "LILS";
+		String downloadType = "http";
+		Response response;
+		JsonObject json;
+
+		// Determine the current download type status; remember, it may not be set at all
+		
+		Boolean disabled = false;
+		String message = "";
+		DownloadType dt = downloadTypeRepository.getDownloadType(facilityName, downloadType);
+		
+		if( dt != null ) {
+			disabled = dt.getDisabled();
+			message = dt.getMessage();
+			System.out.println("DEBUG: AdminRT: initial download type status is {" + disabled + "," + message + "}");
+		} else {
+			System.out.println("DEBUG: AdminRT: initial download type status not found");
+		}
+		
+		if( message.length() == 0 ) {
+			message = "Disabled for testing";
+		}
+		
+		// Toggle the disabled status
+		
+		response = adminResource.setDownloadTypeStatus(downloadType, facilityName, adminSessionId, ! disabled, message);
+		assertEquals(200, response.getStatus());
+		
+		// Now test that it has had the desired result
+		
+		dt = downloadTypeRepository.getDownloadType(facilityName, downloadType);
+		
+		assertNotNull(dt);
+		if( dt != null ) {
+			System.out.println("DEBUG: AdminRT final download type status is {" + dt.getDisabled() + "," + dt.getMessage() + "}");
+			assertTrue(disabled != dt.getDisabled());
+			assertEquals(message, dt.getMessage());
+		}
+		
+		// TODO test that setDownloadTypeStatus produces an error for non-admin users.
+	}
+	
+	@Test
+	public void testClearCachedSize() throws Exception {
+
+		String facilityName = "LILS";
+		String entityType = "dataset";
+		Long id = 3L;
+		Long size = 150L;
+        String key = "getSize:" + entityType + ":" + id;
+		Response response;
+
+		// Set a dummy size (this will overwrite any existing cached value!)
+		
+		cacheRepository.put(key, size);
+		
+		// Now use the API to clear it
+		response = adminResource.clearCachedSize(entityType, id, facilityName, adminSessionId);
+		assertEquals(200, response.getStatus());
+		
+		// and now it should be gone from the repository
+		assertNull(cacheRepository.get(key));
+		
+		// TODO test behaviour for non-admin user		
+	}
+	
+	@Test
+	public void testSetConfVar() throws Exception {
+		
+		String facilityName = "LILS";
+		String name = "testVar";
+		String value = "test value";
+		Response response;
+		
+		// First, check whether the confVar is set to this value already - if so, choose a different value
+		if ( value.equals(confVarRepository.getConfVar(name))) {
+			value = "different test value";
+		}
+		
+		response = adminResource.setConfVar(name, facilityName, adminSessionId, value);
+		assertEquals(200, response.getStatus());
+		
+		assertEquals( value, confVarRepository.getConfVar(name).getValue());
+		
+		// TODO test behaviour for non-admin user
+	}
+	
+	private Download findDownload(List<Download> downloads, Long downloadId) {
+		
+		for ( Download download : downloads ) {
+			if( download.getId() == downloadId ) return download;
+		}
+		return null;		
+	}
+
+}

--- a/src/test/java/org/icatproject/topcat/CacheRepositoryTest.java
+++ b/src/test/java/org/icatproject/topcat/CacheRepositoryTest.java
@@ -10,12 +10,13 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import static org.junit.Assert.*;
 import org.junit.*;
+import org.junit.runner.RunWith;
 import javax.inject.Inject;
 
 
 import javax.ejb.EJB;
 
-
+import org.icatproject.topcat.domain.Cache;
 import org.icatproject.topcat.repository.CacheRepository;
 
 @RunWith(Arquillian.class)
@@ -24,15 +25,13 @@ public class CacheRepositoryTest {
     @Deployment
     public static JavaArchive createDeployment() {
         return ShrinkWrap.create(JavaArchive.class)
-            .addClass(CacheRepository.class)
+            .addClasses(CacheRepository.class, Cache.class)
+            .addAsResource("META-INF/persistence.xml")
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Inject
 	private CacheRepository cacheRepository;
-
-	private static String sessionId;
-
 
 	@Test
 	public void testPutAndGet() throws Exception {
@@ -42,14 +41,9 @@ public class CacheRepositoryTest {
 
 	@Test
 	public void testRemove() {
-		// BR: this test requires the cacheRepository bean to be created,
-		// and I don't know how to do that. I don't think Jody did either,
-		// as all other tests that use cacheRepository have been commented-out!
-		/*
 		String key = "test:remove";
 		cacheRepository.put(key, "Hello World");
 		cacheRepository.remove(key);
 		assertEquals(null,cacheRepository.get(key));
-		*/
 	}
 }

--- a/src/test/java/org/icatproject/topcat/CacheRepositoryTest.java
+++ b/src/test/java/org/icatproject/topcat/CacheRepositoryTest.java
@@ -3,8 +3,14 @@ package org.icatproject.topcat;
 import java.util.*;
 import java.lang.reflect.*;
 
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import static org.junit.Assert.*;
 import org.junit.*;
+import javax.inject.Inject;
 
 
 import javax.ejb.EJB;
@@ -12,9 +18,17 @@ import javax.ejb.EJB;
 
 import org.icatproject.topcat.repository.CacheRepository;
 
+@RunWith(Arquillian.class)
 public class CacheRepositoryTest {
 
-	@EJB
+    @Deployment
+    public static JavaArchive createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class)
+            .addClass(CacheRepository.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
 	private CacheRepository cacheRepository;
 
 	private static String sessionId;
@@ -22,8 +36,8 @@ public class CacheRepositoryTest {
 
 	@Test
 	public void testPutAndGet() throws Exception {
-		//cacheRepository.put("test:1", "Hello World!");
-		//assertEquals( "Hello World!", (String) cacheRepository.get("test:1"));
+		cacheRepository.put("test:1", "Hello World!");
+		assertEquals( "Hello World!", (String) cacheRepository.get("test:1"));
 	}
 
 	@Test

--- a/src/test/java/org/icatproject/topcat/UserResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/UserResourceTest.java
@@ -97,36 +97,4 @@ public class UserResourceTest {
 
 	}
 
-    private Map<String, List<Long>> createEmptyEntityTypeEntityIds(){
-    	Map<String, List<Long>> out = new HashMap<String, List<Long>>();
-		out.put("investigation", new ArrayList<Long>());
-		out.put("dataset", new ArrayList<Long>());
-		out.put("datafile", new ArrayList<Long>());
-		return out;
-    }
-
-
-    class IcatClientUserIsAdmin extends IcatClient {
-
-		public IcatClientUserIsAdmin(String url, String sessionId){
-			super(url, sessionId);
-		}
-
-		protected String[] getAdminUserNames() throws Exception {
-			return new String[] {"simple/root"};
-		}
-    }
-
-    class IcatClientUserNotAdmin extends IcatClient {
-
-		public IcatClientUserNotAdmin(String url, String sessionId){
-			super(url, sessionId);
-		}
-
-		protected String[] getAdminUserNames() throws Exception {
-			return new String[] {"db/test"};
-		}
-    }
-
-
 }

--- a/src/test/java/org/icatproject/topcat/UserResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/UserResourceTest.java
@@ -1,0 +1,132 @@
+package org.icatproject.topcat;
+
+import java.util.*;
+import java.io.File;
+import java.lang.reflect.*;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+import static org.junit.Assert.*;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import javax.inject.Inject;
+
+import javax.json.*;
+import javax.ws.rs.core.Response;
+import javax.ejb.EJB;
+
+import org.icatproject.topcat.httpclient.HttpClient;
+import org.icatproject.topcat.domain.*;
+import java.net.URLEncoder;
+
+import org.icatproject.topcat.repository.CacheRepository;
+import org.icatproject.topcat.repository.CartRepository;
+import org.icatproject.topcat.repository.DownloadRepository;
+import org.icatproject.topcat.repository.DownloadTypeRepository;
+import org.icatproject.topcat.web.rest.UserResource;
+
+import java.sql.*;
+
+@RunWith(Arquillian.class)
+public class UserResourceTest {
+
+	// CURRENT STATUS:
+	// I can only get this to work if I put a cobbled copy of topcat.properties in the root folder.
+	// All attempts to use addAsResource() have failed, and I'm fed up trying to guess (from several million online examples) how it should be used correctly!
+	
+    @Deployment
+    public static JavaArchive createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class)
+            .addClasses(UserResource.class, CacheRepository.class, Cache.class, DownloadRepository.class, DownloadTypeRepository.class, CartRepository.class)
+            .addAsResource("META-INF/persistence.xml")
+            // .addAsResource("topcat.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+	@EJB
+	private DownloadRepository downloadRepository;
+
+	@EJB
+	private DownloadTypeRepository downloadTypeRepository;
+
+	@EJB
+	private CartRepository cartRepository;
+
+	@EJB
+	private CacheRepository cacheRepository;
+	
+	@Inject
+	private UserResource userResource;
+
+	private static String sessionId;
+
+	private Connection connection;
+
+	@Before
+	public void setup() throws Exception {
+		TestHelpers.installTrustManager();
+
+		HttpClient httpClient = new HttpClient("https://localhost:8181/icat");
+		String data = "json=" + URLEncoder.encode("{\"plugin\":\"simple\", \"credentials\":[{\"username\":\"root\"}, {\"password\":\"root\"}]}", "UTF8");
+		String response = httpClient.post("session", new HashMap<String, String>(), data).toString();
+		sessionId = Utils.parseJsonObject(response).getString("sessionId");
+
+		connection = DriverManager.getConnection("jdbc:mysql://localhost:3306/icat", "root", "secret");
+	}
+
+	@Test
+	public void testGetSize() throws Exception {
+		String facilityName = "LILS";
+		String entityType = "investigation";
+		Long entityId = (long) 1;
+		IcatClient icatClient = new IcatClient("https://localhost:8181", sessionId);
+		// UserResource userResource = new UserResource();
+
+		List<Long> emptyIds = new ArrayList<Long>();
+		
+		Response response = userResource.getSize(facilityName,sessionId,entityType,entityId);
+
+		// Actual size value discovered by trial and error!
+		// assertEquals((long) 155062810, Long.parseLong(response.getEntity().toString()));
+		// Possibly more robust:
+		assertTrue(Long.parseLong(response.getEntity().toString()) > (long) 0);
+
+	}
+
+    private Map<String, List<Long>> createEmptyEntityTypeEntityIds(){
+    	Map<String, List<Long>> out = new HashMap<String, List<Long>>();
+		out.put("investigation", new ArrayList<Long>());
+		out.put("dataset", new ArrayList<Long>());
+		out.put("datafile", new ArrayList<Long>());
+		return out;
+    }
+
+
+    class IcatClientUserIsAdmin extends IcatClient {
+
+		public IcatClientUserIsAdmin(String url, String sessionId){
+			super(url, sessionId);
+		}
+
+		protected String[] getAdminUserNames() throws Exception {
+			return new String[] {"simple/root"};
+		}
+    }
+
+    class IcatClientUserNotAdmin extends IcatClient {
+
+		public IcatClientUserNotAdmin(String url, String sessionId){
+			super(url, sessionId);
+		}
+
+		protected String[] getAdminUserNames() throws Exception {
+			return new String[] {"db/test"};
+		}
+    }
+
+
+}

--- a/src/test/java/org/icatproject/topcat/UserResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/UserResourceTest.java
@@ -242,6 +242,32 @@ public class UserResourceTest {
 		assertTrue( newDownload.getIsDeleted() );
 	}
 	
+	@Test
+	public void testGetDownloadTypeStatus() throws Exception {
+
+		String facilityName = "LILS";
+		String downloadType = "http";
+		Response response;
+		JsonObject json;
+
+		response = userResource.getDownloadTypeStatus(downloadType, facilityName, sessionId);
+		assertEquals(200, response.getStatus());
+		
+		json = Utils.parseJsonObject(response.getEntity().toString());
+		assertTrue( json.containsKey("disabled"));
+		assertTrue( json.containsKey("message"));
+		
+		// There's not much we can assume about the actual status;
+		// but should test that the fields contain the correct types
+		
+		try {
+			Boolean disabled = json.getBoolean("disabled");
+			String message = json.getString("message");
+		} catch (Exception e) {
+			fail("One or both fields are not of the correct type: " + e.getMessage() );
+		}
+	}
+	
 	private int getCartSize(Response response) throws Exception {
 		// Trying to write these tests has revealed that UserResource.getSize() is inconsistent!
 		// The Response entity returned when the cart is empty cannot be cast to a Cart, but must be parsed as JSON;

--- a/topcat.properties
+++ b/topcat.properties
@@ -1,0 +1,5 @@
+# Dummy topcat.properties file for integration tests
+facility.list = LILS
+facility.LILS.icatUrl = http://localhost:8080
+facility.LILS.idsUrl = http://localhost:8080
+

--- a/topcat.properties
+++ b/topcat.properties
@@ -2,4 +2,4 @@
 facility.list = LILS
 facility.LILS.icatUrl = http://localhost:8080
 facility.LILS.idsUrl = http://localhost:8080
-
+adminUserNames=simple/root


### PR DESCRIPTION
This PR adds embedded-container tests for the UserResource and AdminResource classes, which provide the bulk of the server-side REST API. It includes a small number of changes to the configuration files used by Vagrant and Travis.
