### PR TITLE
Allow markup in download type descriptions

### DIFF
--- a/yo/app/views/download-cart.html
+++ b/yo/app/views/download-cart.html
@@ -27,7 +27,9 @@
                     </td>
                     <td>
                         <select ng-options="item as item.displayName for item in download.transportTypes track by item.type" ng-model="download.transportType" ng-change="download.updateIsTwoLevel()"></select>
-                        <div ng-if="download.transportType.description">{{download.transportType.description}}</div>
+                        <div ng-if="download.transportType.description">
+                        	<ng-bind-html ng-bind-html="download.transportType.description"></ng-bind-html>
+                        </div>
                     </td>
                     <td>
                         <span ng-if="download.size === undefined" class="loading collapsed"></span><span ng-if="download.size == -1">Unknown</span><span ng-if="download.size != -1">{{download.size | bytes}}</span>


### PR DESCRIPTION
Replaced original angularjs expression with ng-bind-html.
Tried it with this (under globus download type in topcat.json):

"description": "Use Globus to download your data, but with lots of words just to see what happens. And even more! Use Globus to download your data, but with lots of words just to see what happens. And even more! Use Globus to download your data, but with lots of words just to see what happens. And even more! <br/> And what about a <a href=\"http://google.co.uk\" target=\"_blank\">link</a>?"

and both the break and the link work.
Note the use of the target attribute in the link - without it, the link opens in the same window, and the open dialog is lost when we go back.

Fixes #450 