### PR TITLE
Issue#453 pagination duplicates

### DIFF
--- a/src/site/markdown/release-notes.md
+++ b/src/site/markdown/release-notes.md
@@ -8,6 +8,7 @@
   * StatusCheck now logs changes in download statuses
   * StatusCheck now expires downloads on any exception, not just TopcatException (issue #449)
   * Allow HTML markup in download type descriptions (issue #450)
+  * Fix: always order query results by (at least) ID to prevent pagination issues (issue #453)
   
 ## 2.4.4 (1st Jul 2019)
 

--- a/yo/app/scripts/controllers/admin-downloads.controller.js
+++ b/yo/app/scripts/controllers/admin-downloads.controller.js
@@ -96,6 +96,9 @@
                     if(i < sortColumns.length - 1) out.push(',');
                 }
             });
+            // Always order by ID to force an order on rows that are otherwise sort-identical;
+            // This should avoid pagination duplication problems - see issue #453
+            out.push(", download.id asc");
           }
 
           out.push(["limit ?, ?", (page - 1) * pageSize, pageSize])          

--- a/yo/app/scripts/controllers/admin-downloads.controller.js
+++ b/yo/app/scripts/controllers/admin-downloads.controller.js
@@ -99,6 +99,9 @@
             // Always order by ID to force an order on rows that are otherwise sort-identical;
             // This should avoid pagination duplication problems - see issue #453
             out.push(", download.id asc");
+          } else {
+        	  // Order by ID if no other order is defined - in case pagination errors are possible here too
+        	  out.push('order by download.id asc');
           }
 
           out.push(["limit ?, ?", (page - 1) * pageSize, pageSize])          

--- a/yo/app/scripts/controllers/my-data.controller.js
+++ b/yo/app/scripts/controllers/my-data.controller.js
@@ -65,6 +65,10 @@
             sortQuery.push('order by ' + _.map(sortColumns, function(sortColumn){
                 return sortColumn.jpqlSort + ' ' + sortColumn.sort.direction;
             }).join(', '));
+            // Always order by ID to force an order on rows that are otherwise sort-identical;
+            // This should avoid pagination duplication problems - see issue #453
+            // However, BR suspects that the value of sortQuery is never being used! The real work is done by generateQueryBuilder() below.
+            sortQuery.push(', id asc');
         }
 
         var externalGridFilters = tc.ui().externalGridFilters().myData;

--- a/yo/app/scripts/services/tc-icat-query-builder.service.js
+++ b/yo/app/scripts/services/tc-icat-query-builder.service.js
@@ -236,7 +236,7 @@
 
                 // Always order by ID to force an order on rows that are otherwise sort-identical;
                 // This should avoid pagination duplication problems - see issue #453
-                // TODO: should we do this even if no other sorting has been specified?
+                // NOTE: we do this even if no other sorting has been specified.
                 
     			var idField = entityType + '.id';
     			if(entityType == 'proposal'){
@@ -245,6 +245,8 @@
 
     			if(orderByList.length > 0){
                     out.push(['ORDER BY', orderByList.join(', '), ',', idField, 'asc']);
+                } else {
+                	out.push(['ORDER BY', idField, 'asc']);
                 }
 
                 if(!functionName && limitCount && !investigationName){

--- a/yo/app/scripts/services/tc-icat-query-builder.service.js
+++ b/yo/app/scripts/services/tc-icat-query-builder.service.js
@@ -234,8 +234,17 @@
     				out.push(['where', whereQuery]);
     			}
 
-                if(orderByList.length > 0){
-                    out.push(['ORDER BY', orderByList.join(', ')]);
+                // Always order by ID to force an order on rows that are otherwise sort-identical;
+                // This should avoid pagination duplication problems - see issue #453
+                // TODO: should we do this even if no other sorting has been specified?
+                
+    			var idField = entityType + '.id';
+    			if(entityType == 'proposal'){
+    			    idField = 'investigation.id';
+    			}
+
+    			if(orderByList.length > 0){
+                    out.push(['ORDER BY', orderByList.join(', '), ',', idField, 'asc']);
                 }
 
                 if(!functionName && limitCount && !investigationName){


### PR DESCRIPTION
Always order by ID.
Found instances of the pagination problem on a development system; they disappeared after deploying this version; so I am satisfied that this works.

Fixes #453.
