### PR TITLE
Issue#459 download limits ignored

### DIFF
--- a/src/site/markdown/release-notes.md
+++ b/src/site/markdown/release-notes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 2.4.6-SNAPSHOT
+
+  * Ensure download cart button is disabled when limits are exceeded (issue #459)
+
 ## 2.4.5 (15th Oct 2019)
 
   * Improve feedback when getSize requests fail (issue #439)

--- a/yo/app/scripts/controllers/cart.controller.js
+++ b/yo/app/scripts/controllers/cart.controller.js
@@ -57,7 +57,7 @@
                     that.download();
                 },
                 disabled: function(){
-                    return this.enableLimits && !that.isValid;
+                    return that.enableLimits && !that.isValid;
                 },
                 class: "btn btn-primary",
                 translate: "CART.DOWNLOAD_CART_BUTTON.TEXT",
@@ -242,25 +242,29 @@
 
             resetGetTotalsTimeout();
             that.isLoaded = false;
+            console.log('getTotals: setting isValid to false - was ' + that.isValid);
             that.isValid = false;
             that.totalSize = 0;
             that.datafileCount = 0;
 
             return getDatafileCount().then(function(datafileCount){
                 that.datafileCount = datafileCount;
-                if(datafileCount < that.maxDatafileCount){
+                if(datafileCount <= that.maxDatafileCount){
                     return getTotalSize().then(function(totalSize){
                         that.totalSize = totalSize;
                         that.isLoaded = true;
 
-                        if(totalSize < that.maxTotalSize){
+                        if(totalSize <= that.maxTotalSize){
+                        	console.log('getTotals: setting isValid to true');
                             that.isValid = true;
                         } else {
+                        	console.log('getTotals: reject - too big');
                             return $q.reject("Total size too big");
                         }
                     });
                 } else {
                     that.isLoaded = true;
+                    console.log('getTotals: reject - too many');
                     return $q.reject("Too many files");
                 }
             });

--- a/yo/app/scripts/controllers/cart.controller.js
+++ b/yo/app/scripts/controllers/cart.controller.js
@@ -242,7 +242,6 @@
 
             resetGetTotalsTimeout();
             that.isLoaded = false;
-            console.log('getTotals: setting isValid to false - was ' + that.isValid);
             that.isValid = false;
             that.totalSize = 0;
             that.datafileCount = 0;
@@ -255,16 +254,13 @@
                         that.isLoaded = true;
 
                         if(totalSize <= that.maxTotalSize){
-                        	console.log('getTotals: setting isValid to true');
                             that.isValid = true;
                         } else {
-                        	console.log('getTotals: reject - too big');
                             return $q.reject("Total size too big");
                         }
                     });
                 } else {
                     that.isLoaded = true;
-                    console.log('getTotals: reject - too many');
                     return $q.reject("Too many files");
                 }
             });


### PR DESCRIPTION
Ensure that the Download Cart button is disabled when count/size limits are exceeded.
Fixes #459.