### PR TITLE
Issue#458 report download cart failure

### DIFF
--- a/src/site/markdown/release-notes.md
+++ b/src/site/markdown/release-notes.md
@@ -3,6 +3,7 @@
 ## 2.4.6-SNAPSHOT
 
   * Ensure download cart button is disabled when limits are exceeded (issue #459)
+  * Inform user when cart submission for download fails (issue #458)
 
 ## 2.4.5 (15th Oct 2019)
 


### PR DESCRIPTION
If the submitCart() request fails from the Download Cart dialog, the user is informed, and (if there are no other successful download submissions) the "new download added" tooltip does not appear.

Fixes #458.
