### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
 python:
   - "3.1"
 jdk:
-  - openjdk8
+  - oraclejdk8
 install:
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install 6.10.0
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 sudo: true
-dist: trusty
+dist: xenial
 rvm:
   - 2.3
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ install:
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install 6.10.0
 before_script:
   - chmod 0755 ci/travis.rb
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start -screen 0 1280x1024x16
   - nohup bash -c "./nodemodules/protractor/bin/webdriver-manager start 2>&1 &"
   - sleep 5
 script:
@@ -19,6 +17,7 @@ addons:
   chrome: stable
 services:
   - mysql
+  - xvfb
 after_failure:
   - cat target/surefire-reports/*.txt
   - cat install/glassfish4/glassfish/domains/domain1/logs/*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ rvm:
   - 2.3
 python:
   - "3.1"
+jdk:
+  - openjdk8
 install:
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install 6.10.0
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,7 @@ before_script:
 script:
   - ci/travis.rb
 addons:
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - google-chrome-stable
+  chrome: stable
 services:
   - mysql
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 sudo: true
 dist: xenial
 rvm:
-  - 2.3
+  - 2.5
 python:
   - "3.1"
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
 python:
   - "3.1"
 jdk:
-  - oraclejdk8
+  - openjdk8
 install:
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install 6.10.0
 before_script:

--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -27,7 +27,7 @@ exec %{
   sudo apt-get --assume-yes install apache2 git software-properties-common python-software-properties unzip build-essential dos2unix
   sudo apt-get install libgconf2-dev -y
 
-  echo "USE mysql; UPDATE user SET plugin = 'mysql_native_password' WHERE user='root'; UPDATE user SET authentication_string=PASSWORD('secret') WHERE user='root'; FLUSH PRIVILEGES;" | mysql -u root
+  echo "USE mysql; ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'secret'; FLUSH PRIVILEGES;" | mysql -u root
   echo "create database icat;" | mysql -u root --password=secret
   echo "create database topcat;" | mysql -u root --password=secret
   echo "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '' WITH GRANT OPTION" | mysql -u root --password=secret

--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -27,7 +27,7 @@ exec %{
   sudo apt-get --assume-yes install apache2 git software-properties-common python-software-properties unzip build-essential dos2unix
   sudo apt-get install libgconf2-dev -y
 
-  echo "USE mysql; UPDATE user SET password=PASSWORD('secret') WHERE user='root'; FLUSH PRIVILEGES; " | mysql -u root
+  echo "USE mysql; UPDATE user SET authentication_string=PASSWORD('secret') WHERE user='root'; FLUSH PRIVILEGES; " | mysql -u root
   echo "create database icat;" | mysql -u root --password=secret
   echo "create database topcat;" | mysql -u root --password=secret
   echo "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '' WITH GRANT OPTION" | mysql -u root --password=secret

--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -30,7 +30,6 @@ exec %{
   echo "USE mysql; UPDATE user SET authentication_string=PASSWORD('secret') WHERE user='root'; FLUSH PRIVILEGES; " | mysql -u root
   echo "create database icat;" | mysql -u root --password=secret
   echo "create database topcat;" | mysql -u root --password=secret
-  echo "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '' WITH GRANT OPTION" | mysql -u root --password=secret
 
   sudo cp provision/000-default.conf /etc/apache2/sites-available
   sudo a2enmod headers

--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -30,7 +30,7 @@ exec %{
   echo "USE mysql; ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'secret'; FLUSH PRIVILEGES;" | mysql -u root
   echo "create database icat;" | mysql -u root --password=secret
   echo "create database topcat;" | mysql -u root --password=secret
-  echo "GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' IDENTIFIED BY '' WITH GRANT OPTION" | mysql -u root --password=secret
+  echo "GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' WITH GRANT OPTION" | mysql -u root --password=secret
 
   sudo cp provision/000-default.conf /etc/apache2/sites-available
   sudo a2enmod headers
@@ -42,6 +42,7 @@ exec %{
   mv payara41 glassfish4
 
   export PATH="$PATH:#{install_dir}/glassfish4/glassfish/bin"
+  export PATH="$PATH:/home/mnf98541/glassfish4/glassfish/bin"
 
   asadmin start-domain
   asadmin set server.http-service.access-log.format="common"

--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -37,8 +37,8 @@ exec %{
   sudo a2enmod rewrite
   sudo /etc/init.d/apache2 restart
 
-  wget --quiet https://s3-eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/Payara+4.1.2.172/payara-4.1.2.172.zip
-  unzip payara-4.1.2.172.zip
+  wget --quiet https://s3-eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/Payara+4.1.2.181/payara-4.1.2.181.zip
+  unzip payara-4.1.2.181.zip
   mv payara41 glassfish4
 
   export PATH="$PATH:#{install_dir}/glassfish4/glassfish/bin"

--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -27,9 +27,10 @@ exec %{
   sudo apt-get --assume-yes install apache2 git software-properties-common python-software-properties unzip build-essential dos2unix
   sudo apt-get install libgconf2-dev -y
 
-  echo "USE mysql; UPDATE user SET authentication_string=PASSWORD('secret') WHERE user='root'; FLUSH PRIVILEGES; " | mysql -u root
+  echo "USE mysql; UPDATE user SET plugin = 'mysql_native_password' WHERE user='root'; UPDATE user SET authentication_string=PASSWORD('secret') WHERE user='root'; FLUSH PRIVILEGES;" | mysql -u root
   echo "create database icat;" | mysql -u root --password=secret
   echo "create database topcat;" | mysql -u root --password=secret
+  echo "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '' WITH GRANT OPTION" | mysql -u root --password=secret
 
   sudo cp provision/000-default.conf /etc/apache2/sites-available
   sudo a2enmod headers

--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -23,6 +23,7 @@ exec %{
 
   cd install
 
+  sudo apt-get update
   sudo apt-get --assume-yes install apache2 git software-properties-common python-software-properties unzip build-essential dos2unix
   sudo apt-get install libgconf2-dev -y
 

--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -30,7 +30,7 @@ exec %{
   echo "USE mysql; ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'secret'; FLUSH PRIVILEGES;" | mysql -u root
   echo "create database icat;" | mysql -u root --password=secret
   echo "create database topcat;" | mysql -u root --password=secret
-  echo "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '' WITH GRANT OPTION" | mysql -u root --password=secret
+  echo "GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' IDENTIFIED BY '' WITH GRANT OPTION" | mysql -u root --password=secret
 
   sudo cp provision/000-default.conf /etc/apache2/sites-available
   sudo a2enmod headers

--- a/provision/topcat-setup.properties
+++ b/provision/topcat-setup.properties
@@ -6,7 +6,7 @@
 !db.password = APP
 
 # MySQL Database
-db.url=jdbc:mysql://localhost:3306/topcat?useSSL=false
+db.url=jdbc:mysql://localhost:3306/topcat
 db.driver=com.mysql.jdbc.jdbc2.optional.MysqlDataSource
 db.username=root
 db.password=secret

--- a/provision/topcat-setup.properties
+++ b/provision/topcat-setup.properties
@@ -6,7 +6,7 @@
 !db.password = APP
 
 # MySQL Database
-db.url=jdbc:mysql://localhost:3306/topcat
+db.url=jdbc:mysql://localhost:3306/topcat?useSSL=false
 db.driver=com.mysql.jdbc.jdbc2.optional.MysqlDataSource
 db.username=root
 db.password=secret

--- a/src/test/java/org/icatproject/topcat/AdminResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/AdminResourceTest.java
@@ -38,22 +38,25 @@ import java.sql.*;
 public class AdminResourceTest {
 
 	/*
-	 * CURRENT STATUS:
-	 * I can only get this to work if I put a cobbled copy of topcat.properties in the root folder.
-	 * All attempts to use addAsResource() have failed, and I'm fed up trying to guess (from several million online examples) how it should be used correctly!
+	 * CURRENT STATUS: I can only get this to work if I put a cobbled copy of
+	 * topcat.properties in the root folder. All attempts to use addAsResource()
+	 * have failed, and I'm fed up trying to guess (from several million online
+	 * examples) how it should be used correctly!
 	 *
-	 * Of course, these are not unit tests, but use an embedded container and a local ICAT/IDS which we assume to be populated appropriately.
+	 * Of course, these are not unit tests, but use an embedded container and a
+	 * local ICAT/IDS which we assume to be populated appropriately.
 	 */
-	
-    @Deployment
-    public static JavaArchive createDeployment() {
-        return ShrinkWrap.create(JavaArchive.class)
-            .addClasses(AdminResource.class, CacheRepository.class, DownloadRepository.class, DownloadTypeRepository.class, ConfVarRepository.class)
-            .addPackages(true,"org.icatproject.topcat.domain","org.icatproject.topcat.exceptions")
-            .addAsResource("META-INF/persistence.xml")
-            // .addAsResource("topcat.properties")
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
-    }
+
+	@Deployment
+	public static JavaArchive createDeployment() {
+		return ShrinkWrap.create(JavaArchive.class)
+				.addClasses(AdminResource.class, CacheRepository.class, DownloadRepository.class,
+						DownloadTypeRepository.class, ConfVarRepository.class)
+				.addPackages(true, "org.icatproject.topcat.domain", "org.icatproject.topcat.exceptions")
+				.addAsResource("META-INF/persistence.xml")
+				// .addAsResource("topcat.properties")
+				.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+	}
 
 	@EJB
 	private DownloadRepository downloadRepository;
@@ -61,33 +64,39 @@ public class AdminResourceTest {
 	@EJB
 	private DownloadTypeRepository downloadTypeRepository;
 
-    @EJB
-    private ConfVarRepository confVarRepository;
+	@EJB
+	private ConfVarRepository confVarRepository;
 
 	@EJB
 	private CacheRepository cacheRepository;
-	
+
 	@Inject
 	private AdminResource adminResource;
 
 	private static String adminSessionId;
 	private static String nonAdminSessionId;
 
+	@BeforeClass
+	public void beforeAll() {
+		TestHelpers.installTrustManager();
+	}
+
 	@Before
 	public void setup() throws Exception {
-		TestHelpers.installTrustManager();
-
 		HttpClient httpClient = new HttpClient("https://localhost:8181/icat");
-		
+
 		// Log in as an admin user
-		
-		String data = "json=" + URLEncoder.encode("{\"plugin\":\"simple\", \"credentials\":[{\"username\":\"root\"}, {\"password\":\"root\"}]}", "UTF8");
+
+		String data = "json=" + URLEncoder.encode(
+				"{\"plugin\":\"simple\", \"credentials\":[{\"username\":\"root\"}, {\"password\":\"root\"}]}", "UTF8");
 		String response = httpClient.post("session", new HashMap<String, String>(), data).toString();
 		adminSessionId = Utils.parseJsonObject(response).getString("sessionId");
-		
+
 		// Also log in as a non-admin user
 
-		data = "json=" + URLEncoder.encode("{\"plugin\":\"simple\", \"credentials\":[{\"username\":\"nonroot\"}, {\"password\":\"nonroot\"}]}", "UTF8");
+		data = "json=" + URLEncoder.encode(
+				"{\"plugin\":\"simple\", \"credentials\":[{\"username\":\"nonroot\"}, {\"password\":\"nonroot\"}]}",
+				"UTF8");
 		response = httpClient.post("session", new HashMap<String, String>(), data).toString();
 		nonAdminSessionId = Utils.parseJsonObject(response).getString("sessionId");
 	}
@@ -96,135 +105,143 @@ public class AdminResourceTest {
 	public void testIsValidSession() throws Exception {
 		String facilityName = "LILS";
 		Response response;
-		
+
 		// Should be true for an admin user
-		
+
 		response = adminResource.isValidSession(facilityName, adminSessionId);
 		assertEquals(200, response.getStatus());
-		assertEquals("true", (String)response.getEntity());
-		
+		assertEquals("true", (String) response.getEntity());
+
 		// Should be false for a non-admin (but valid) user
-		
+
 		response = adminResource.isValidSession(facilityName, nonAdminSessionId);
 		assertEquals(200, response.getStatus());
-		assertEquals("false", (String)response.getEntity());
-		
+		assertEquals("false", (String) response.getEntity());
+
 		// Request should fail for a nonsense sessionId
 		response = adminResource.isValidSession(facilityName, "nonsense id");
 		// Expected this to raise a BadRequestException, but surprisingly it doesn't
 		assertEquals(200, response.getStatus());
-		assertEquals("false", (String)response.getEntity());
+		assertEquals("false", (String) response.getEntity());
 	}
-	
+
 	@Test
 	public void testDownloadAPI() throws Exception {
 		String facilityName = "LILS";
 		Response response;
 		JsonObject json;
 		List<Download> downloads;
-		
+
 		// Create a new download for the test
 		Download testDownload = new Download();
 		testDownload.setFacilityName(facilityName);
 		testDownload.setSessionId(adminSessionId);
 		testDownload.setStatus(DownloadStatus.PREPARING);
 		testDownload.setIsDeleted(false);
-		
+
 		// Other fields that can't be null, but which we (hopefully) don't really need:
 		testDownload.setUserName("simple/root");
 		testDownload.setFileName("testFile.txt");
 		testDownload.setTransport("http");
-		
+
 		downloadRepository.save(testDownload);
-		
+
 		// Get the current downloads - may not be empty
 		// It appears queryOffset cannot be empty!
 		String queryOffset = "1 = 1";
 		response = adminResource.getDownloads(facilityName, adminSessionId, queryOffset);
 		assertEquals(200, response.getStatus());
-		
-		downloads = (List<Download>)response.getEntity();
-		
+
+		downloads = (List<Download>) response.getEntity();
+
 		// Check that the result tallies with the DownloadRepository contents
-		
-        Map<String, Object> params = new HashMap<String, Object>();
-        params.put("queryOffset", queryOffset);
-        List<Download> repoDownloads = new ArrayList<Download>();
+
+		Map<String, Object> params = new HashMap<String, Object>();
+		params.put("queryOffset", queryOffset);
+		List<Download> repoDownloads = new ArrayList<Download>();
 		repoDownloads = downloadRepository.getDownloads(params);
-		
-		assertEquals( repoDownloads.size(), downloads.size() );
-		for( Download download : repoDownloads ) {
-			assertNotNull( findDownload(downloads,download.getId()));
+
+		assertEquals(repoDownloads.size(), downloads.size());
+		for (Download download : repoDownloads) {
+			assertNotNull(findDownload(downloads, download.getId()));
 		}
-		
+
 		// Next, change the download status. Must be different from the current status!
 		String downloadStatus = "EXPIRED";
-		if( testDownload.getStatus().equals(DownloadStatus.valueOf(downloadStatus))) {
+		if (testDownload.getStatus().equals(DownloadStatus.valueOf(downloadStatus))) {
 			downloadStatus = "PAUSED";
 		}
-		
+
 		response = adminResource.setDownloadStatus(testDownload.getId(), facilityName, adminSessionId, downloadStatus);
 		assertEquals(200, response.getStatus());
-		
+
 		// and test that the new status has been set
-		
+
 		response = adminResource.getDownloads(facilityName, adminSessionId, queryOffset);
 		assertEquals(200, response.getStatus());
-		downloads = (List<Download>)response.getEntity();
-		
-		testDownload = findDownload(downloads,testDownload.getId());
-		
-		// To be thorough, we ought to check that ONLY the status field has changed. Not going to!
-		assertEquals( DownloadStatus.valueOf(downloadStatus), testDownload.getStatus() );
-		
+		downloads = (List<Download>) response.getEntity();
+
+		testDownload = findDownload(downloads, testDownload.getId());
+
+		// To be thorough, we ought to check that ONLY the status field has changed. Not
+		// going to!
+		assertEquals(DownloadStatus.valueOf(downloadStatus), testDownload.getStatus());
+
 		// Now toggle the deleted status - may have been deleted already!
 		Boolean currentDeleted = testDownload.getIsDeleted();
-		
-		response = adminResource.deleteDownload(testDownload.getId(), facilityName, adminSessionId, ! currentDeleted);
+
+		response = adminResource.deleteDownload(testDownload.getId(), facilityName, adminSessionId, !currentDeleted);
 		assertEquals(200, response.getStatus());
-		
-		// and check that it has worked (again, not bothering to check that nothing else has changed)
-		
+
+		// and check that it has worked (again, not bothering to check that nothing else
+		// has changed)
+
 		response = adminResource.getDownloads(facilityName, adminSessionId, queryOffset);
 		assertEquals(200, response.getStatus());
-		downloads = (List<Download>)response.getEntity();
-		
-		testDownload = findDownload(downloads,testDownload.getId());
-		assertTrue( testDownload.getIsDeleted() != currentDeleted );
-		
-		// Test that getDownloadStatus() etc. produce an error response for a non-admin user
-		
+		downloads = (List<Download>) response.getEntity();
+
+		testDownload = findDownload(downloads, testDownload.getId());
+		assertTrue(testDownload.getIsDeleted() != currentDeleted);
+
+		// Test that getDownloadStatus() etc. produce an error response for a non-admin
+		// user
+
 		try {
 			response = adminResource.getDownloads(facilityName, nonAdminSessionId, queryOffset);
 			// We should not see the following
-			System.out.println("DEBUG: AdminRT.getDownloads response: " + response.getStatus() + ", " + (String)response.getEntity());
+			System.out.println("DEBUG: AdminRT.getDownloads response: " + response.getStatus() + ", "
+					+ (String) response.getEntity());
 			fail("AdminResource.getDownloads did not raise exception for non-admin user");
 		} catch (ForbiddenException fe) {
 			assertTrue(true);
 		}
 
 		try {
-			response = adminResource.setDownloadStatus(testDownload.getId(), facilityName, nonAdminSessionId, downloadStatus);
+			response = adminResource.setDownloadStatus(testDownload.getId(), facilityName, nonAdminSessionId,
+					downloadStatus);
 			// We should not see the following
-			System.out.println("DEBUG: AdminRT.setDownloadStatus response: " + response.getStatus() + ", " + (String)response.getEntity());
+			System.out.println("DEBUG: AdminRT.setDownloadStatus response: " + response.getStatus() + ", "
+					+ (String) response.getEntity());
 			fail("AdminResource.setDownloadStatus did not raise exception for non-admin user");
 		} catch (ForbiddenException fe) {
 			assertTrue(true);
 		}
 
 		try {
-			response = adminResource.deleteDownload(testDownload.getId(), facilityName, nonAdminSessionId, ! currentDeleted);
+			response = adminResource.deleteDownload(testDownload.getId(), facilityName, nonAdminSessionId,
+					!currentDeleted);
 			// We should not see the following
-			System.out.println("DEBUG: AdminRT.deleteDownload response: " + response.getStatus() + ", " + (String)response.getEntity());
+			System.out.println("DEBUG: AdminRT.deleteDownload response: " + response.getStatus() + ", "
+					+ (String) response.getEntity());
 			fail("AdminResource.deleteDownload did not raise exception for non-admin user");
 		} catch (ForbiddenException fe) {
 			assertTrue(true);
 		}
-		
+
 		// Remove the test download from the repository
 		downloadRepository.removeDownload(testDownload.getId());
 	}
-	
+
 	@Test
 	public void testSetDownloadTypeStatus() throws Exception {
 
@@ -233,65 +250,71 @@ public class AdminResourceTest {
 		Response response;
 		JsonObject json;
 
-		// Determine the current download type status; remember, it may not be set at all
-		
+		// Determine the current download type status; remember, it may not be set at
+		// all
+
 		Boolean disabled = false;
 		String message = "";
 		DownloadType dt = downloadTypeRepository.getDownloadType(facilityName, downloadType);
-		
-		if( dt != null ) {
+
+		if (dt != null) {
 			disabled = dt.getDisabled();
 			message = dt.getMessage();
 			System.out.println("DEBUG: AdminRT: initial download type status is {" + disabled + "," + message + "}");
 		} else {
 			System.out.println("DEBUG: AdminRT: initial download type status not found");
 		}
-		
-		if( message.length() == 0 ) {
+
+		if (message.length() == 0) {
 			message = "Disabled for testing";
 		}
-		
+
 		// Toggle the disabled status
-		
-		response = adminResource.setDownloadTypeStatus(downloadType, facilityName, adminSessionId, ! disabled, message);
+
+		response = adminResource.setDownloadTypeStatus(downloadType, facilityName, adminSessionId, !disabled, message);
 		assertEquals(200, response.getStatus());
-		
+
 		// Now test that it has had the desired result
-		
+
 		dt = downloadTypeRepository.getDownloadType(facilityName, downloadType);
-		
+
 		assertNotNull(dt);
-		if( dt != null ) {
-			System.out.println("DEBUG: AdminRT final download type status is {" + dt.getDisabled() + "," + dt.getMessage() + "}");
+		if (dt != null) {
+			System.out.println(
+					"DEBUG: AdminRT final download type status is {" + dt.getDisabled() + "," + dt.getMessage() + "}");
 			assertTrue(disabled != dt.getDisabled());
 			assertEquals(message, dt.getMessage());
 		}
-		
+
 		// Test that setDownloadTypeStatus produces an error for non-admin users.
-		
+
 		try {
-			response = adminResource.setDownloadTypeStatus(downloadType, facilityName, nonAdminSessionId, ! disabled, message);
+			response = adminResource.setDownloadTypeStatus(downloadType, facilityName, nonAdminSessionId, !disabled,
+					message);
 			// We should not see the following
-			System.out.println("DEBUG: AdminRT.setDownloadTypeStatus response: " + response.getStatus() + ", " + (String)response.getEntity());
+			System.out.println("DEBUG: AdminRT.setDownloadTypeStatus response: " + response.getStatus() + ", "
+					+ (String) response.getEntity());
 			fail("AdminResource.setDownloadTypeStatus did not raise exception for non-admin user");
 		} catch (ForbiddenException fe) {
 			assertTrue(true);
 		}
-		
+
 		// Finally, ought to reset the disabled status to the original value!
 		// (Though we could have used a dummy download type for the test...)
 		// However, this won't reset an originally-empty message.
 
-		if( dt != null ) {
-			response = adminResource.setDownloadTypeStatus(downloadType, facilityName, adminSessionId, disabled, message);
+		if (dt != null) {
+			response = adminResource.setDownloadTypeStatus(downloadType, facilityName, adminSessionId, disabled,
+					message);
 			assertEquals(200, response.getStatus());
 		} else {
-			// There was no entry for this download type previously.  As the status is false by default, make sure that's what we set it to now!
+			// There was no entry for this download type previously. As the status is false
+			// by default, make sure that's what we set it to now!
 			response = adminResource.setDownloadTypeStatus(downloadType, facilityName, adminSessionId, false, message);
 			assertEquals(200, response.getStatus());
 		}
 	}
-	
+
 	@Test
 	public void testClearCachedSize() throws Exception {
 
@@ -299,66 +322,70 @@ public class AdminResourceTest {
 		String entityType = "dataset";
 		Long id = 3L;
 		Long size = 150L;
-        String key = "getSize:" + entityType + ":" + id;
+		String key = "getSize:" + entityType + ":" + id;
 		Response response;
 
 		// Set a dummy size (this will overwrite any existing cached value!)
-		
+
 		cacheRepository.put(key, size);
-		
+
 		// Now use the API to clear it
 		response = adminResource.clearCachedSize(entityType, id, facilityName, adminSessionId);
 		assertEquals(200, response.getStatus());
-		
+
 		// and now it should be gone from the repository
 		assertNull(cacheRepository.get(key));
-		
-		// Test behaviour for non-admin user		
+
+		// Test behaviour for non-admin user
 		try {
 			response = adminResource.clearCachedSize(entityType, id, facilityName, nonAdminSessionId);
 			// We should not see the following
-			System.out.println("DEBUG: AdminRT.clearCachedSize response: " + response.getStatus() + ", " + (String)response.getEntity());
+			System.out.println("DEBUG: AdminRT.clearCachedSize response: " + response.getStatus() + ", "
+					+ (String) response.getEntity());
 			fail("AdminResource.clearCachedSize did not raise exception for non-admin user");
 		} catch (ForbiddenException fe) {
 			assertTrue(true);
 		}
 	}
-	
+
 	@Test
 	public void testSetConfVar() throws Exception {
-		
+
 		String facilityName = "LILS";
 		String name = "testVar";
 		String value = "test value";
 		Response response;
-		
-		// First, check whether the confVar is set to this value already - if so, choose a different value
-		if ( value.equals(confVarRepository.getConfVar(name))) {
+
+		// First, check whether the confVar is set to this value already - if so, choose
+		// a different value
+		if (value.equals(confVarRepository.getConfVar(name))) {
 			value = "different test value";
 		}
-		
+
 		response = adminResource.setConfVar(name, facilityName, adminSessionId, value);
 		assertEquals(200, response.getStatus());
-		
-		assertEquals( value, confVarRepository.getConfVar(name).getValue());
-		
-		// Test behaviour for non-admin user		
+
+		assertEquals(value, confVarRepository.getConfVar(name).getValue());
+
+		// Test behaviour for non-admin user
 		try {
 			response = adminResource.setConfVar(name, facilityName, nonAdminSessionId, value);
 			// We should not see the following
-			System.out.println("DEBUG: AdminRT.setConfVar response: " + response.getStatus() + ", " + (String)response.getEntity());
+			System.out.println("DEBUG: AdminRT.setConfVar response: " + response.getStatus() + ", "
+					+ (String) response.getEntity());
 			fail("AdminResource.setConfVar did not raise exception for non-admin user");
 		} catch (ForbiddenException fe) {
 			assertTrue(true);
 		}
 	}
-	
+
 	private Download findDownload(List<Download> downloads, Long downloadId) {
-		
-		for ( Download download : downloads ) {
-			if( download.getId() == downloadId ) return download;
+
+		for (Download download : downloads) {
+			if (download.getId() == downloadId)
+				return download;
 		}
-		return null;		
+		return null;
 	}
 
 }

--- a/src/test/java/org/icatproject/topcat/AdminResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/AdminResourceTest.java
@@ -77,7 +77,7 @@ public class AdminResourceTest {
 	private static String nonAdminSessionId;
 
 	@BeforeClass
-	public void beforeAll() {
+	public static void beforeAll() {
 		TestHelpers.installTrustManager();
 	}
 

--- a/src/test/java/org/icatproject/topcat/IcatClientTest.java
+++ b/src/test/java/org/icatproject/topcat/IcatClientTest.java
@@ -27,13 +27,12 @@ public class IcatClientTest {
 	private Connection connection;
 
 	@BeforeClass
-	public void beforeAll() {
+	public static void beforeAll() {
 		TestHelpers.installTrustManager();
 	}
 
 	@Before
 	public void setup() throws Exception {
-
 		HttpClient httpClient = new HttpClient("https://localhost:8181/icat");
 		String data = "json=" + URLEncoder.encode(
 				"{\"plugin\":\"simple\", \"credentials\":[{\"username\":\"root\"}, {\"password\":\"root\"}]}", "UTF8");

--- a/src/test/java/org/icatproject/topcat/IcatClientTest.java
+++ b/src/test/java/org/icatproject/topcat/IcatClientTest.java
@@ -26,12 +26,17 @@ public class IcatClientTest {
 
 	private Connection connection;
 
+	@BeforeClass
+	public void beforeAll() {
+		TestHelpers.installTrustManager();
+	}
+
 	@Before
 	public void setup() throws Exception {
-		TestHelpers.installTrustManager();
 
 		HttpClient httpClient = new HttpClient("https://localhost:8181/icat");
-		String data = "json=" + URLEncoder.encode("{\"plugin\":\"simple\", \"credentials\":[{\"username\":\"root\"}, {\"password\":\"root\"}]}", "UTF8");
+		String data = "json=" + URLEncoder.encode(
+				"{\"plugin\":\"simple\", \"credentials\":[{\"username\":\"root\"}, {\"password\":\"root\"}]}", "UTF8");
 		String response = httpClient.post("session", new HashMap<String, String>(), data).toString();
 		sessionId = Utils.parseJsonObject(response).getString("sessionId");
 
@@ -70,7 +75,7 @@ public class IcatClientTest {
 		results = icatClient.getEntities("datafile", ids);
 		assertEquals(0, results.size());
 
-		List<Long>  investigationIds = new ArrayList<Long>();
+		List<Long> investigationIds = new ArrayList<Long>();
 		ResultSet investigations = connection.createStatement().executeQuery("SELECT * from INVESTIGATION limit 0, 1");
 		investigations.next();
 		investigationIds.add(investigations.getLong("ID"));
@@ -78,7 +83,7 @@ public class IcatClientTest {
 		results = icatClient.getEntities("investigation", investigationIds);
 		assertEquals(1, results.size());
 
-		List<Long>  datasetIds = new ArrayList<Long>();
+		List<Long> datasetIds = new ArrayList<Long>();
 		ResultSet datasets = connection.createStatement().executeQuery("SELECT * from DATASET limit 0, 1");
 		datasets.next();
 		datasetIds.add(datasets.getLong("ID"));
@@ -87,7 +92,7 @@ public class IcatClientTest {
 		assertEquals(1, results.size());
 		assertNotNull(results.get(0).getJsonObject("investigation"));
 
-		List<Long>  datafileIds = new ArrayList<Long>();
+		List<Long> datafileIds = new ArrayList<Long>();
 		ResultSet datafiles = connection.createStatement().executeQuery("SELECT * from DATAFILE");
 		datafiles.next();
 		datafileIds.add(datafiles.getLong("ID"));
@@ -97,7 +102,7 @@ public class IcatClientTest {
 		assertNotNull(results.get(0).getJsonObject("dataset"));
 		assertNotNull(results.get(0).getJsonObject("dataset").getJsonObject("investigation"));
 
-		for(long i = 2; i <= 10001; i++){
+		for (long i = 2; i <= 10001; i++) {
 			datafiles.next();
 			datafileIds.add(datafiles.getLong("ID"));
 		}
@@ -107,67 +112,62 @@ public class IcatClientTest {
 
 	}
 
-
 	@Test
 	public void testGetFullName() throws Exception {
 		IcatClient icatClient = new IcatClient("https://localhost:8181", sessionId);
 		String fullName = icatClient.getFullName();
 
 		assertNotNull(fullName);
-		//assertTrue(fullName.length() > 0);
+		// assertTrue(fullName.length() > 0);
 	}
 
 	/*
-	@Test
-	public void testGetSize() throws Exception {
-		IcatClient icatClient = new IcatClient("https://localhost:8181", sessionId);
+	 * @Test public void testGetSize() throws Exception { IcatClient icatClient =
+	 * new IcatClient("https://localhost:8181", sessionId);
+	 * 
+	 * List<Long> emptyIds = new ArrayList<Long>();
+	 * 
+	 * assertEquals((long) 0, (long) icatClient.getSize(cacheRepository, emptyIds,
+	 * emptyIds, emptyIds));
+	 * 
+	 * List<Long> ids = new ArrayList<Long>(); ids.add((long) 1); ids.add((long) 2);
+	 * ids.add((long) 3);
+	 * 
+	 * assertTrue(icatClient.getSize(cacheRepository, ids, emptyIds, emptyIds) >
+	 * (long) 0); assertTrue(icatClient.getSize(cacheRepository, emptyIds, ids,
+	 * emptyIds) > (long) 0); assertTrue(icatClient.getSize(cacheRepository,
+	 * emptyIds, emptyIds, ids) > (long) 0);
+	 * assertTrue(icatClient.getSize(cacheRepository, ids, ids, ids) > (long) 0); }
+	 */
 
-		List<Long> emptyIds = new ArrayList<Long>();
-
-		assertEquals((long) 0, (long) icatClient.getSize(cacheRepository, emptyIds, emptyIds, emptyIds));
-
-		List<Long> ids = new ArrayList<Long>();
-		ids.add((long) 1);
-		ids.add((long) 2);
-		ids.add((long) 3);
-
-		assertTrue(icatClient.getSize(cacheRepository, ids, emptyIds, emptyIds) > (long) 0);
-		assertTrue(icatClient.getSize(cacheRepository, emptyIds, ids, emptyIds) > (long) 0);
-		assertTrue(icatClient.getSize(cacheRepository, emptyIds, emptyIds, ids) > (long) 0);
-		assertTrue(icatClient.getSize(cacheRepository, ids, ids, ids) > (long) 0);
-	}
-	*/
-
-    private Map<String, List<Long>> createEmptyEntityTypeEntityIds(){
-    	Map<String, List<Long>> out = new HashMap<String, List<Long>>();
+	private Map<String, List<Long>> createEmptyEntityTypeEntityIds() {
+		Map<String, List<Long>> out = new HashMap<String, List<Long>>();
 		out.put("investigation", new ArrayList<Long>());
 		out.put("dataset", new ArrayList<Long>());
 		out.put("datafile", new ArrayList<Long>());
 		return out;
-    }
+	}
 
+	class IcatClientUserIsAdmin extends IcatClient {
 
-    class IcatClientUserIsAdmin extends IcatClient {
-
-		public IcatClientUserIsAdmin(String url, String sessionId){
+		public IcatClientUserIsAdmin(String url, String sessionId) {
 			super(url, sessionId);
 		}
 
 		protected String[] getAdminUserNames() throws Exception {
-			return new String[] {"simple/root"};
+			return new String[] { "simple/root" };
 		}
-    }
+	}
 
-    class IcatClientUserNotAdmin extends IcatClient {
+	class IcatClientUserNotAdmin extends IcatClient {
 
-		public IcatClientUserNotAdmin(String url, String sessionId){
+		public IcatClientUserNotAdmin(String url, String sessionId) {
 			super(url, sessionId);
 		}
 
 		protected String[] getAdminUserNames() throws Exception {
-			return new String[] {"db/test"};
+			return new String[] { "db/test" };
 		}
-    }
-
+	}
 
 }

--- a/src/test/java/org/icatproject/topcat/TestHelpers.java
+++ b/src/test/java/org/icatproject/topcat/TestHelpers.java
@@ -11,12 +11,7 @@ import javax.net.ssl.SSLSession;
 
 public class TestHelpers {
 
-    static boolean installed = false;
-
     public static void installTrustManager() {
-        // if (installed) {
-        // return;
-        // }
 
         // Create a trust manager that does not validate certificate chains
         // Equivalent to --no-certificate-check in wget
@@ -53,7 +48,5 @@ public class TestHelpers {
         }
         // log message
         System.out.println("Trust manager set up successfully");
-
-        installed = true;
     }
 }

--- a/src/test/java/org/icatproject/topcat/TestHelpers.java
+++ b/src/test/java/org/icatproject/topcat/TestHelpers.java
@@ -1,47 +1,59 @@
 package org.icatproject.topcat;
 
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import javax.net.ssl.HttpsURLConnection;
 import java.security.cert.X509Certificate;
 import java.security.SecureRandom;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
 
 public class TestHelpers {
 
     static boolean installed = false;
 
     public static void installTrustManager() {
-        if(installed){
+        if (installed) {
             return;
         }
 
         // Create a trust manager that does not validate certificate chains
         // Equivalent to --no-certificate-check in wget
         // Only needed if system does not have access to correct CA keys
-        TrustManager[] trustAllCerts = new TrustManager[]{
-            new X509TrustManager() {
-                public X509Certificate[] getAcceptedIssuers() {
-                    return null;
-                }
-                public void checkClientTrusted(X509Certificate[] certs, String authType) {
-                }
-                public void checkServerTrusted(X509Certificate[] certs, String authType) {
-                }
+        TrustManager[] trustAllCerts = new TrustManager[] { new X509TrustManager() {
+            public X509Certificate[] getAcceptedIssuers() {
+                return null;
+            }
+
+            public void checkClientTrusted(X509Certificate[] certs, String authType) {
+            }
+
+            public void checkServerTrusted(X509Certificate[] certs, String authType) {
+            }
+        } };
+
+        // Create all-trusting host name verifier
+        HostnameVerifier allHostsValid = new HostnameVerifier() {
+            public boolean verify(String hostname, SSLSession session) {
+                return true;
             }
         };
- 
+
         // Install the all-trusting trust manager
         try {
             SSLContext sc = SSLContext.getInstance("SSL");
             sc.init(null, trustAllCerts, new SecureRandom());
             HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+
+            // Install the all-trusting host verifier
+            HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
         } catch (Exception e) {
             System.err.println(e.getClass().getSimpleName() + " setting trust manager: " + e.getMessage());
         }
         // log message
         System.out.println("Trust manager set up successfully");
-        
+
         installed = true;
     }
 }

--- a/src/test/java/org/icatproject/topcat/TestHelpers.java
+++ b/src/test/java/org/icatproject/topcat/TestHelpers.java
@@ -14,9 +14,9 @@ public class TestHelpers {
     static boolean installed = false;
 
     public static void installTrustManager() {
-        if (installed) {
-            return;
-        }
+        // if (installed) {
+        // return;
+        // }
 
         // Create a trust manager that does not validate certificate chains
         // Equivalent to --no-certificate-check in wget

--- a/src/test/java/org/icatproject/topcat/UserResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/UserResourceTest.java
@@ -35,22 +35,25 @@ import java.sql.*;
 public class UserResourceTest {
 
 	/*
-	 * CURRENT STATUS:
-	 * I can only get this to work if I put a cobbled copy of topcat.properties in the root folder.
-	 * All attempts to use addAsResource() have failed, and I'm fed up trying to guess (from several million online examples) how it should be used correctly!
+	 * CURRENT STATUS: I can only get this to work if I put a cobbled copy of
+	 * topcat.properties in the root folder. All attempts to use addAsResource()
+	 * have failed, and I'm fed up trying to guess (from several million online
+	 * examples) how it should be used correctly!
 	 *
-	 * Of course, these are not unit tests, but use an embedded container and a local ICAT/IDS which we assume to be populated appropriately.
+	 * Of course, these are not unit tests, but use an embedded container and a
+	 * local ICAT/IDS which we assume to be populated appropriately.
 	 */
-	
-    @Deployment
-    public static JavaArchive createDeployment() {
-        return ShrinkWrap.create(JavaArchive.class)
-            .addClasses(UserResource.class, CacheRepository.class, DownloadRepository.class, DownloadTypeRepository.class, CartRepository.class)
-            .addPackages(true,"org.icatproject.topcat.domain","org.icatproject.topcat.exceptions")
-            .addAsResource("META-INF/persistence.xml")
-            // .addAsResource("topcat.properties")
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
-    }
+
+	@Deployment
+	public static JavaArchive createDeployment() {
+		return ShrinkWrap.create(JavaArchive.class)
+				.addClasses(UserResource.class, CacheRepository.class, DownloadRepository.class,
+						DownloadTypeRepository.class, CartRepository.class)
+				.addPackages(true, "org.icatproject.topcat.domain", "org.icatproject.topcat.exceptions")
+				.addAsResource("META-INF/persistence.xml")
+				// .addAsResource("topcat.properties")
+				.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+	}
 
 	@EJB
 	private DownloadRepository downloadRepository;
@@ -63,7 +66,7 @@ public class UserResourceTest {
 
 	@EJB
 	private CacheRepository cacheRepository;
-	
+
 	@Inject
 	private UserResource userResource;
 
@@ -71,12 +74,16 @@ public class UserResourceTest {
 
 	private Connection connection;
 
-	@Before
-	public void setup() throws Exception {
+	@BeforeClass
+	public void beforeAll() {
 		TestHelpers.installTrustManager();
+	}
 
+	@BeforeClass
+	public void setup() throws Exception {
 		HttpClient httpClient = new HttpClient("https://localhost:8181/icat");
-		String data = "json=" + URLEncoder.encode("{\"plugin\":\"simple\", \"credentials\":[{\"username\":\"root\"}, {\"password\":\"root\"}]}", "UTF8");
+		String data = "json=" + URLEncoder.encode(
+				"{\"plugin\":\"simple\", \"credentials\":[{\"username\":\"root\"}, {\"password\":\"root\"}]}", "UTF8");
 		String response = httpClient.post("session", new HashMap<String, String>(), data).toString();
 		sessionId = Utils.parseJsonObject(response).getString("sessionId");
 
@@ -91,75 +98,80 @@ public class UserResourceTest {
 		IcatClient icatClient = new IcatClient("https://localhost:8181", sessionId);
 
 		List<Long> emptyIds = new ArrayList<Long>();
-		
-		Response response = userResource.getSize(facilityName,sessionId,entityType,entityId);
+
+		Response response = userResource.getSize(facilityName, sessionId, entityType, entityId);
 
 		// Actual size value for investigation id=1 discovered by trial and error!
-		// assertEquals((long) 155062810, Long.parseLong(response.getEntity().toString()));
+		// assertEquals((long) 155062810,
+		// Long.parseLong(response.getEntity().toString()));
 		// Possibly more robust:
 		assertTrue(Long.parseLong(response.getEntity().toString()) > (long) 0);
 	}
-	
+
 	@Test
 	public void testCart() throws Exception {
 		String facilityName = "LILS";
-		
+
 		Response response;
-		
+
 		// ENSURE that the cart is empty initially,
 		// albeit by using an undocumented feature of the API!
-		
+
 		response = userResource.deleteCartItems(facilityName, sessionId, "*");
 		assertEquals(200, response.getStatus());
 
 		// Now the cart ought to be empty
-		
+
 		response = userResource.getCart(facilityName, sessionId);
 		assertEquals(200, response.getStatus());
 		assertEquals(0, getCartSize(response));
-		
-		// If the cart wasn't empty initially, we won't reach this point, so won't "pollute" a non-empty cart
-		// We ought to update the Cart DB directly, but let's assume that addCartItems() works correctly...
-		// We assume that there is a dataset with id = 1, and that simple/root can see it.
-		
+
+		// If the cart wasn't empty initially, we won't reach this point, so won't
+		// "pollute" a non-empty cart
+		// We ought to update the Cart DB directly, but let's assume that addCartItems()
+		// works correctly...
+		// We assume that there is a dataset with id = 1, and that simple/root can see
+		// it.
+
 		response = userResource.addCartItems(facilityName, sessionId, "dataset 1");
 		assertEquals(200, response.getStatus());
-		
+
 		response = userResource.getCart(facilityName, sessionId);
 		assertEquals(200, response.getStatus());
 		assertEquals(1, getCartSize(response));
-		
+
 		// Now we need to remove the cart item again;
-		// Again, this ought to be done directly, rather than using the methods we should be testing independently!
-		
+		// Again, this ought to be done directly, rather than using the methods we
+		// should be testing independently!
+
 		response = userResource.deleteCartItems(facilityName, sessionId, "dataset 1");
 		assertEquals(200, response.getStatus());
 		assertEquals(0, getCartSize(response));
 	}
-	
+
 	@Test
 	public void testSubmitCart() throws Exception {
 		String facilityName = "LILS";
 		Response response;
 		JsonObject json;
 		List<Download> downloads;
-		
+
 		// Get the initial state of the downloads - may not be empty
 		// It appears queryOffset cannot be empty!
 		String queryOffset = "1 = 1";
 		response = userResource.getDownloads(facilityName, sessionId, queryOffset);
 		assertEquals(200, response.getStatus());
-		
-		downloads = (List<Download>)response.getEntity();
+
+		downloads = (List<Download>) response.getEntity();
 		int initialDownloadsSize = downloads.size();
-		
+
 		// TEST logging
-		System.out.println("DEBUG testSubmitCart: initial downloads size: " + initialDownloadsSize );
-		
+		System.out.println("DEBUG testSubmitCart: initial downloads size: " + initialDownloadsSize);
+
 		// Put something into the Cart, so we have something to submit
 		response = userResource.addCartItems(facilityName, sessionId, "dataset 1");
 		assertEquals(200, response.getStatus());
-		
+
 		// Now submit it
 		String transport = "http";
 		String email = "";
@@ -168,80 +180,82 @@ public class UserResourceTest {
 		response = userResource.submitCart(facilityName, sessionId, transport, email, fileName, zipType);
 		assertEquals(200, response.getStatus());
 		json = Utils.parseJsonObject(response.getEntity().toString());
-		
+
 		// The returned cart should be empty
 		assertEquals(0, json.getJsonArray("cartItems").size());
-		
+
 		// and the downloadId should be positive
 		Long downloadId = json.getJsonNumber("downloadId").longValue();
 		assertTrue(downloadId > 0);
-		
+
 		// Now, there should be one download, whose downloadId matches
 		response = userResource.getDownloads(facilityName, sessionId, queryOffset);
 		assertEquals(200, response.getStatus());
-		
+
 		// Doesn't parse as JSON, try a direct cast
-		
-		downloads = (List<Download>)response.getEntity();
-		
+
+		downloads = (List<Download>) response.getEntity();
+
 		// In a clean world, we could do this:
 		//
 		// assertEquals(1, downloads.size());
 		// assertEquals( downloadId, downloads.get(0).getId() );
 		//
 		// but we can't assume there were no other downloads in the list, so instead:
-		
-		assertEquals( initialDownloadsSize + 1, downloads.size() );
-		
-		Download newDownload = findDownload(downloads,downloadId);
-		assertNotNull( newDownload );
-		assertEquals( facilityName, newDownload.getFacilityName() );
-		assertEquals( "simple/root", newDownload.getUserName() );
-		assertEquals( transport, newDownload.getTransport() );
+
+		assertEquals(initialDownloadsSize + 1, downloads.size());
+
+		Download newDownload = findDownload(downloads, downloadId);
+		assertNotNull(newDownload);
+		assertEquals(facilityName, newDownload.getFacilityName());
+		assertEquals("simple/root", newDownload.getUserName());
+		assertEquals(transport, newDownload.getTransport());
 		// Email is slightly fiddly:
-		if( email.equals("")) {
-			assertEquals( null, newDownload.getEmail() );
+		if (email.equals("")) {
+			assertEquals(null, newDownload.getEmail());
 		} else {
-			assertEquals( email, newDownload.getEmail() );
+			assertEquals(email, newDownload.getEmail());
 		}
-		assertEquals( fileName, newDownload.getFileName() );
-		assertFalse( newDownload.getIsDeleted() );
-		
+		assertEquals(fileName, newDownload.getFileName());
+		assertFalse(newDownload.getIsDeleted());
+
 		// Next, change the download status. Must be different from the current status!
 		String downloadStatus = "EXPIRED";
-		if( newDownload.getStatus().equals(DownloadStatus.valueOf(downloadStatus))) {
+		if (newDownload.getStatus().equals(DownloadStatus.valueOf(downloadStatus))) {
 			downloadStatus = "PAUSED";
 		}
-		
+
 		response = userResource.setDownloadStatus(downloadId, facilityName, sessionId, downloadStatus);
 		assertEquals(200, response.getStatus());
-		
+
 		// and test that the new status has been set
-		
+
 		response = userResource.getDownloads(facilityName, sessionId, queryOffset);
 		assertEquals(200, response.getStatus());
-		downloads = (List<Download>)response.getEntity();
-		
-		newDownload = findDownload(downloads,downloadId);
-		
-		// To be thorough, we ought to check that ONLY the status field has changed. Not going to!
-		assertEquals( DownloadStatus.valueOf(downloadStatus), newDownload.getStatus() );
-		
+		downloads = (List<Download>) response.getEntity();
+
+		newDownload = findDownload(downloads, downloadId);
+
+		// To be thorough, we ought to check that ONLY the status field has changed. Not
+		// going to!
+		assertEquals(DownloadStatus.valueOf(downloadStatus), newDownload.getStatus());
+
 		// Now flag the download as deleted
-		
+
 		response = userResource.deleteDownload(downloadId, facilityName, sessionId, true);
 		assertEquals(200, response.getStatus());
-		
-		// and check that it has worked (again, not bothering to check that nothing else has changed)
-		
+
+		// and check that it has worked (again, not bothering to check that nothing else
+		// has changed)
+
 		response = userResource.getDownloads(facilityName, sessionId, queryOffset);
 		assertEquals(200, response.getStatus());
-		downloads = (List<Download>)response.getEntity();
-		
-		newDownload = findDownload(downloads,downloadId);
-		assertTrue( newDownload.getIsDeleted() );
+		downloads = (List<Download>) response.getEntity();
+
+		newDownload = findDownload(downloads, downloadId);
+		assertTrue(newDownload.getIsDeleted());
 	}
-	
+
 	@Test
 	public void testGetDownloadTypeStatus() throws Exception {
 
@@ -252,37 +266,40 @@ public class UserResourceTest {
 
 		response = userResource.getDownloadTypeStatus(downloadType, facilityName, sessionId);
 		assertEquals(200, response.getStatus());
-		
+
 		json = Utils.parseJsonObject(response.getEntity().toString());
-		assertTrue( json.containsKey("disabled"));
-		assertTrue( json.containsKey("message"));
-		
+		assertTrue(json.containsKey("disabled"));
+		assertTrue(json.containsKey("message"));
+
 		// There's not much we can assume about the actual status;
 		// but should test that the fields contain the correct types
-		
+
 		try {
 			Boolean disabled = json.getBoolean("disabled");
 			String message = json.getString("message");
 		} catch (Exception e) {
-			fail("One or both fields are not of the correct type: " + e.getMessage() );
+			fail("One or both fields are not of the correct type: " + e.getMessage());
 		}
 	}
-	
+
 	private int getCartSize(Response response) throws Exception {
-		// Trying to write these tests has revealed that UserResource.getSize() is inconsistent!
-		// The Response entity returned when the cart is empty cannot be cast to a Cart, but must be parsed as JSON;
-		// but the entity returned for a non-empty cart *cannot* be parsed as JSON, but must be cast instead!
+		// Trying to write these tests has revealed that UserResource.getSize() is
+		// inconsistent!
+		// The Response entity returned when the cart is empty cannot be cast to a Cart,
+		// but must be parsed as JSON;
+		// but the entity returned for a non-empty cart *cannot* be parsed as JSON, but
+		// must be cast instead!
 		// We can't tell whether or not the cart is empty without trying to read it!
 		// Hence this rather ugly and hard-won code...
-		
+
 		int size;
-		
+
 		try {
 			// This works for a non-empty cart (but then fails the assertion)
-			Cart cart = (Cart)response.getEntity();
+			Cart cart = (Cart) response.getEntity();
 			size = cart.getCartItems().size();
 			System.out.println("DEBUG: Cast cart worked, size = " + size);
-			
+
 			// Just for completeness' sake, let's see what JSON parsing does in this case:
 			try {
 				JsonObject json = Utils.parseJsonObject(response.getEntity().toString());
@@ -291,25 +308,26 @@ public class UserResourceTest {
 			} catch (Exception e) {
 				System.out.println("DEBUG: json parsing failed, when cast size = " + size);
 			}
-			
+
 		} catch (Exception e) {
-			
+
 			// This works for an empty cart (but not for a non-empty one)
 			System.out.println("DEBUG: Cast cart failed, try json parsing instead");
 			JsonObject json = Utils.parseJsonObject(response.getEntity().toString());
 			size = json.getJsonArray("cartItems").size();
 			System.out.println("DEBUG: json parsing worked, size = " + size);
 		}
-		
+
 		return size;
 	}
-	
+
 	private Download findDownload(List<Download> downloads, Long downloadId) {
-		
-		for ( Download download : downloads ) {
-			if( download.getId() == downloadId ) return download;
+
+		for (Download download : downloads) {
+			if (download.getId() == downloadId)
+				return download;
 		}
-		return null;		
+		return null;
 	}
 
 }

--- a/src/test/java/org/icatproject/topcat/UserResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/UserResourceTest.java
@@ -75,11 +75,11 @@ public class UserResourceTest {
 	private Connection connection;
 
 	@BeforeClass
-	public void beforeAll() {
+	public static void beforeAll() {
 		TestHelpers.installTrustManager();
 	}
 
-	@BeforeClass
+	@Before
 	public void setup() throws Exception {
 		HttpClient httpClient = new HttpClient("https://localhost:8181/icat");
 		String data = "json=" + URLEncoder.encode(


### PR DESCRIPTION
This fixes the Travis build. Chrome no longer supports `Ubuntu Trusty`, which required upgrading the travis build to use `xenial`, which comes with other updates such as MySQL, which needed fixes.

Additionally, for some reason now the trust manager helper needs to be run in each test suite rather than just once, so I have made it a `BeforeClass` action and removed the `installed` check