### PR TITLE
Fix vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -127,6 +127,8 @@ Vagrant.configure(2) do |config|
     
     curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
     sudo apt-get --assume-yes install nodejs maven phantomjs
+    mkdir /home/vagrant/.m2
+    cp /vagrant/provision/settings.xml /home/vagrant/.m2/settings.xml
     sudo update-ca-certificates -f
     sudo npm install -g bower
     sudo npm install -g grunt-cli
@@ -139,8 +141,8 @@ Vagrant.configure(2) do |config|
 
     curl -sSL https://get.rvm.io | bash
     source /home/vagrant/.rvm/scripts/rvm
-    rvm install 2.3.1
-    rvm use 2.3.1 --default
+    rvm install 2.7.1
+    rvm use 2.7.1 --default
     gem install faker rest-client
     ruby /vagrant/tools/lorum_facility_generator.rb
     ruby /vagrant/provision/populate_lucene.rb

--- a/provision/settings.xml
+++ b/provision/settings.xml
@@ -1,0 +1,22 @@
+<settings>
+  <mirrors>
+    <mirror>
+      <id>central-secure</id>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+  <profiles>
+    <profile>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <serverUrl>https://localhost:8080</serverUrl>
+        <luceneUrl>https://localhost:8080</luceneUrl>
+        <javax.net.ssl.trustStore>/home/vagrant/glassfish4/glassfish/domains/domain1/config/cacerts.jks</javax.net.ssl.trustStore>
+        <containerHome>/home/vagrant/glassfish4</containerHome>
+      </properties>
+    </profile>
+  </profiles>
+</settings>


### PR DESCRIPTION
The vagrant build currently fails due to both the ruby version being too old and due to default maven version installed not using HTTPS and the central repositories now requiring HTTPS.