### PR TITLE
Add @JsonbTransient annotations for Payara 5 compatability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,12 @@
 			<version>7.0</version>
 		</dependency>
 		<dependency>
+			<!-- JSON-B API from JavaEE 8, which gives the @JsonbTransient annotation required for Payara 5 -->
+			<groupId>javax.json.bind</groupId>
+			<artifactId>javax.json.bind-api</artifactId>
+			<version>1.0</version>
+		</dependency>
+		<dependency>
 		     <groupId>javax.websocket</groupId>
 		     <artifactId>javax.websocket-api</artifactId>
 		     <version>1.1</version>

--- a/src/main/java/org/icatproject/topcat/domain/CartItem.java
+++ b/src/main/java/org/icatproject/topcat/domain/CartItem.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.json.bind.annotation.JsonbTransient;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -95,6 +96,7 @@ public class CartItem implements Serializable {
         this.parentEntities = parentEntities;
     }
 
+    @JsonbTransient
     @XmlTransient
     public Cart getCart() {
         return cart;

--- a/src/main/java/org/icatproject/topcat/domain/DownloadItem.java
+++ b/src/main/java/org/icatproject/topcat/domain/DownloadItem.java
@@ -2,6 +2,7 @@ package org.icatproject.topcat.domain;
 
 import java.io.Serializable;
 
+import javax.json.bind.annotation.JsonbTransient;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -77,6 +78,7 @@ public class DownloadItem implements Serializable {
         this.entityId = entityId;
     }
 
+    @JsonbTransient
     @XmlTransient
     public Download getDownload() {
         return download;

--- a/src/main/java/org/icatproject/topcat/domain/ParentEntity.java
+++ b/src/main/java/org/icatproject/topcat/domain/ParentEntity.java
@@ -2,6 +2,7 @@ package org.icatproject.topcat.domain;
 
 import java.io.Serializable;
 
+import javax.json.bind.annotation.JsonbTransient;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -64,6 +65,7 @@ public class ParentEntity implements Serializable{
         this.entityId = entityId;
     }
 
+    @JsonbTransient
     @XmlTransient
     public CartItem getCartItem() {
         return cartItem;


### PR DESCRIPTION
In the REST interface, JAX-RS is responsible for marshalling GenericEntity into JSON. In Payara 5, the marshaller has changed from MOXy to Yasson. Yasson is compliant with the JSON-B standard introduced in JavaEE 8, which requires `@JsonbTransient` annotations instead of `@XmlTransient` annotations.

This PR adds the required `@JsonbTransient` annotations from the JSON-B API. This does not change the behaviour on Payara 4, which still obeys the `@XmlTransient` annotations.