### PR TITLE
Add `remove` Form Parameter to /cartItems

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -126,12 +126,13 @@ Vagrant.configure(2) do |config|
 
     
     curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
-    sudo apt-get --assume-yes install nodejs maven phantomjs
+    sudo apt-get --assume-yes install maven
+    sudo apt-get --assume-yes --force-yes install nodejs phantomjs # There are problems and -y was used without --force-yes
     mkdir /home/vagrant/.m2
     cp /vagrant/provision/settings.xml /home/vagrant/.m2/settings.xml
     sudo update-ca-certificates -f
     sudo npm install -g bower
-    sudo npm install -g grunt-cli
+    sudo npm install -g grunt-cli@1.3.2
     cd /vagrant/yo
     bower install
     sudo chown -R vagrant:vagrant /home/vagrant/.npm
@@ -139,7 +140,7 @@ Vagrant.configure(2) do |config|
     sudo dos2unix /etc/profile.d/phantomjs_bin.sh
     source /etc/profile.d/phantomjs_bin.sh
 
-    curl -sSL https://get.rvm.io | bash
+    curl -sSLk https://get.rvm.io | bash
     source /home/vagrant/.rvm/scripts/rvm
     rvm install 2.7.1
     rvm use 2.7.1 --default
@@ -159,7 +160,7 @@ Vagrant.configure(2) do |config|
     sudo chmod 755 /usr/bin/topcat
     sudo dos2unix /usr/bin/topcat
     topcat build_install
-    asadmin -t set applications.application.topcat-2.4.8.deployment-order=140
+    asadmin -t set applications.application.topcat-2.4.9-SNAPSHOT.deployment-order=140
 
   }
 end

--- a/ci/travis.rb
+++ b/ci/travis.rb
@@ -134,7 +134,7 @@ exec %{
   ./setup install
   cd ../
 
-  asadmin -t set applications.application.topcat-2.4.8.deployment-order=140
+  asadmin -t set applications.application.topcat-2.4.9-SNAPSHOT.deployment-order=140
 
   cd ../yo
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.icatproject</groupId>
 	<artifactId>topcat</artifactId>
 	<packaging>war</packaging>
-	<version>2.4.8</version>
+	<version>2.4.9-SNAPSHOT</version>
 	<name>TopCAT</name>
 	<description>Web frontend for multiple ICATs</description>
 

--- a/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
+++ b/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
@@ -28,6 +28,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.GenericEntity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.DefaultValue;
 
 import org.icatproject.topcat.domain.*;
 import org.icatproject.topcat.exceptions.*;
@@ -371,7 +372,7 @@ public class UserResource {
 	@Path("/cart/{facilityName}/cartItems")
 	@Produces({ MediaType.APPLICATION_JSON })
 	public Response addCartItems(@PathParam("facilityName") String facilityName, 
-			@FormParam("sessionId") String sessionId, @FormParam("items") String items, @FormParam("remove") Boolean remove)
+			@FormParam("sessionId") String sessionId, @FormParam("items") String items, @DefaultValue("false") @FormParam("remove") Boolean remove)
 			throws TopcatException, MalformedURLException, ParseException {
 
 		logger.info("addCartItems() called");

--- a/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
+++ b/src/main/java/org/icatproject/topcat/web/rest/UserResource.java
@@ -342,6 +342,13 @@ public class UserResource {
 	 *            investigation) and entity id pairs in the form: investigation
 	 *            2, datafile 1
 	 *
+	 * @param remove
+	 *            flag to determine whether the request should be used to remove
+	 *            items from the cart or not. If set to true, the items given in
+	 *            the request will be removed from the cart (equivalent to the
+	 *            DELETE endpoint). The default is to add to the cart (i.e.
+	 *            false)
+	 *
 	 * @return returns the cart object in the form:
 	 *         {"cartItems":[{"entityId":18178,"entityType":"datafile","id":1,
 	 *         "name":"tenenvironment.rhy","parentEntities":[{"entityId":182,
@@ -364,10 +371,16 @@ public class UserResource {
 	@Path("/cart/{facilityName}/cartItems")
 	@Produces({ MediaType.APPLICATION_JSON })
 	public Response addCartItems(@PathParam("facilityName") String facilityName, 
-			@FormParam("sessionId") String sessionId, @FormParam("items") String items)
+			@FormParam("sessionId") String sessionId, @FormParam("items") String items, @FormParam("remove") Boolean remove)
 			throws TopcatException, MalformedURLException, ParseException {
 
 		logger.info("addCartItems() called");
+
+		if (remove == true) {
+			logger.info("Calling deleteCartItems() from addCartItems()");
+			Response deleteCartResponse = this.deleteCartItems(facilityName, sessionId, items);
+			return deleteCartResponse;
+		}
 
 		String icatUrl = getIcatUrl( facilityName );
 		IcatClient icatClient = new IcatClient(icatUrl, sessionId);

--- a/src/test/java/org/icatproject/topcat/UserResourceTest.java
+++ b/src/test/java/org/icatproject/topcat/UserResourceTest.java
@@ -133,7 +133,7 @@ public class UserResourceTest {
 		// We assume that there is a dataset with id = 1, and that simple/root can see
 		// it.
 
-		response = userResource.addCartItems(facilityName, sessionId, "dataset 1");
+		response = userResource.addCartItems(facilityName, sessionId, "dataset 1", false);
 		assertEquals(200, response.getStatus());
 
 		response = userResource.getCart(facilityName, sessionId);
@@ -169,7 +169,7 @@ public class UserResourceTest {
 		System.out.println("DEBUG testSubmitCart: initial downloads size: " + initialDownloadsSize);
 
 		// Put something into the Cart, so we have something to submit
-		response = userResource.addCartItems(facilityName, sessionId, "dataset 1");
+		response = userResource.addCartItems(facilityName, sessionId, "dataset 1", false);
 		assertEquals(200, response.getStatus());
 
 		// Now submit it


### PR DESCRIPTION
As per https://github.com/ral-facilities/datagateway/issues/1210#issuecomment-1092983096, this PR adds a form parameter called `remove` on the POST request to `/cartItems`. This parameter acts as a convenient way to remove items from the cart using POST, rather than DELETE. As such, when `remove` is set to true, it calls `deleteCartItems()` instead of executing the logic from `addCartItems()`. 

The logic I've added means that `remove` is false by default; it's not explicitly set to false but the call to `deleteCartItems()` only occurs when it is true so if `remove` isn't specified in the request, items will be added to the cart (i.e. the existing behaviour).

I edited the tests as needed and checked they pass. I created a new VM (using the Vagrantfile on this repo) to ensure I had the correct testing environment.

There are no specific tests for `addCartItems()` so I haven't added any new ones testing this new behaviour. I did manually test on my own machine adding and removing items from the cart, although that was only a couple at a time (rather than the potentially hundreds that one might experience on a production machine).